### PR TITLE
Bugfix rotate numba

### DIFF
--- a/elastica/_elastica_numba/_joint.py
+++ b/elastica/_elastica_numba/_joint.py
@@ -186,7 +186,7 @@ def _calculate_contact_forces(
 
 @numba.njit(cache=True)
 def _aabbs_not_intersecting(aabb_one, aabb_two):
-    """ Returns true if not intersecting else false"""
+    """Returns true if not intersecting else false"""
     if (aabb_one[0, 1] < aabb_two[0, 0]) | (aabb_one[0, 0] > aabb_two[0, 1]):
         return 1
     if (aabb_one[1, 1] < aabb_two[1, 0]) | (aabb_one[1, 0] > aabb_two[1, 1]):

--- a/elastica/_elastica_numba/_rotations.py
+++ b/elastica/_elastica_numba/_rotations.py
@@ -46,6 +46,7 @@ def _get_rotation_matrix(scale: float, axis_collection):
     return rot_mat
 
 
+@njit(cache=True)
 def _rotate(director_collection, scale: float, axis_collection):
     """
     Does alibi rotations

--- a/examples/Visualization/_povmacros.py
+++ b/examples/Visualization/_povmacros.py
@@ -189,7 +189,7 @@ class Stages:
         self._light_assign = defaultdict(list)
 
     def add_camera(self, name, **kwargs):
-        """ Add camera (viewpoint) """
+        """Add camera (viewpoint)"""
         self.cameras.append(self.Camera(name=name, **kwargs))
 
     def add_light(self, camera_id=-1, **kwargs):

--- a/tests/test_elastica_numba/test_rod_nb.py
+++ b/tests/test_elastica_numba/test_rod_nb.py
@@ -26,7 +26,7 @@ class TestRod:
 # https://docs.pytest.org/en/latest/fixture.html
 @pytest.fixture(scope="module", params=[15, 31])
 def load_data_for_bootstrapping_state(request):
-    """ Yield states for bootstrapping """
+    """Yield states for bootstrapping"""
     n_elem = request.param
     n_nodes = n_elem + 1
     dim = 3

--- a/tests/test_elastica_numba/test_timestepper_nb.py
+++ b/tests/test_elastica_numba/test_timestepper_nb.py
@@ -37,7 +37,7 @@ from elastica.utils import Tolerance
 
 
 class TestExtendStepperInterface:
-    """ TODO add documentation """
+    """TODO add documentation"""
 
     class MockSymplecticStepper:
         Tag = SymplecticStepperTag()

--- a/tests/test_elastica_numpy/test_rod_np.py
+++ b/tests/test_elastica_numpy/test_rod_np.py
@@ -26,7 +26,7 @@ class TestRod:
 # https://docs.pytest.org/en/latest/fixture.html
 @pytest.fixture(scope="module", params=[15, 31])
 def load_data_for_bootstrapping_state(request):
-    """ Yield states for bootstrapping """
+    """Yield states for bootstrapping"""
     n_elem = request.param
     n_nodes = n_elem + 1
     dim = 3

--- a/tests/test_elastica_numpy/test_timestepper_np.py
+++ b/tests/test_elastica_numpy/test_timestepper_np.py
@@ -37,7 +37,7 @@ from elastica.utils import Tolerance
 
 
 class TestExtendStepperInterface:
-    """ TODO add documentation """
+    """TODO add documentation"""
 
     class MockSymplecticStepper:
         Tag = SymplecticStepperTag()


### PR DESCRIPTION
This PR fixes a bug in `_rotate` function of Numba branch.`_rotate` function did not have njit decorator, so it was not a Numba decorated function and can cause problems if users want to use `_rotate` function inside the another Numba decorated function.
This commit adds `njit` decorator to the `_rotate` function located under `elastica/_elastica_numba/_rotations.py`.
`Black` formatting is also done.