### PR TITLE
Callback mechanism had ambiguous floating-point division (issue 35)

### DIFF
--- a/elastica/timestepper/symplectic_steppers.py
+++ b/elastica/timestepper/symplectic_steppers.py
@@ -1,6 +1,7 @@
 __doc__ = """Symplectic time steppers and concepts for integrating the kinematic and dynamic equations of rod-like objects.  """
 
 import numpy as np
+import math
 
 # from elastica._elastica_numba._timestepper._symplectic_steppers import (
 #     SymplecticStepperTag,
@@ -105,7 +106,7 @@ class _SystemCollectionStepper:
         SystemCollection.constrain_values(time)
 
         # Call back function, will call the user defined call back functions and store data
-        SystemCollection.apply_callbacks(time, int(time / dt))
+        SystemCollection.apply_callbacks(time, round(time / dt))
 
         # Zero out the external forces and torques
         for system in SystemCollection._memory_blocks:

--- a/elastica/wrappers/base_system.py
+++ b/elastica/wrappers/base_system.py
@@ -131,6 +131,10 @@ class BaseSystemCollection(MutableSequence):
 
         """
 
+        # FIXME: This is probably the most bizarre way to collect the functions. It is definitely
+        # impressive and even surprising that it is working, but it is far from readable and maintainable.
+        # The code is difficult to debug, because the behavior is un-interpretable except during run-time.
+        # We need a lot more documentation on this part: clear explanation and reasoning.
         def get_methods_from_feature_classes(method_name: str):
             methods = [
                 [v for (k, v) in cls.__dict__.items() if k.endswith(method_name)]
@@ -146,7 +150,9 @@ class BaseSystemCollection(MutableSequence):
         self._features_that_constrain_rates = get_methods_from_feature_classes(
             "_constrain_rates"
         )
-        self._callback_features = get_methods_from_feature_classes("_callBack")
+        self._callback_features = get_methods_from_feature_classes(
+            "_callback_execution"
+        )
         finalize_methods = get_methods_from_feature_classes("_finalize")
 
         # construct memory block

--- a/tests/test_wrappers/test_base_system.py
+++ b/tests/test_wrappers/test_base_system.py
@@ -203,7 +203,7 @@ class TestBaseSystemWithFeaturesUsingCosseratRod:
         simulator_class.collect_diagnostics(rod).using(legal_callback)
         simulator_class.finalize()
         # After finalize check if the created callback object is instance of the class we have given.
-        assert isinstance(simulator_class._callbacks[-1][-1], legal_callback)
+        assert isinstance(simulator_class._callback_list[-1][-1], legal_callback)
 
         # TODO: this is a dummy test for apply_callbacks find a better way to test them
         simulator_class.apply_callbacks(time=0, current_step=0)

--- a/tests/test_wrappers/test_callbacks.py
+++ b/tests/test_wrappers/test_callbacks.py
@@ -131,7 +131,7 @@ class TestCallBacksMixin:
         scwc.append(mock_rod)
 
         _mock_callback = scwc.collect_diagnostics(mock_rod)
-        assert _mock_callback in scwc._callbacks
+        assert _mock_callback in scwc._callback_list
         assert _mock_callback.__class__ == _CallBack
 
     from elastica.callback_functions import CallBackBaseClass
@@ -165,7 +165,7 @@ class TestCallBacksMixin:
 
         scwc._finalize()
 
-        for (x, y) in scwc._callbacks:
+        for (x, y) in scwc._callback_list:
             assert type(x) is int
             assert type(y) is callback_cls
 
@@ -177,6 +177,6 @@ class TestCallBacksMixin:
 
         # this is allowed to fail (not critical)
         num = -np.inf
-        for (x, _) in scwc._callbacks:
+        for (x, _) in scwc._callback_list:
             assert num < x
             num = x


### PR DESCRIPTION
- Fix #35 - floating-point division ambiguity
- Refactor names in callback module. (Someone marked `TODO`)
  - Incorporate the changes in test files.