### PR TITLE
[Core] Wrapper Redesign

### DIFF
--- a/elastica/wrappers/base_system.py
+++ b/elastica/wrappers/base_system.py
@@ -51,6 +51,9 @@ class BaseSystemCollection(MutableSequence):
         # from Controllers, Environments which are
         # tacked on to the SystemCollection in a sim.
         self._features = NotImplemented
+        # Flag Finalize: Finalizing twice will cause an error,
+        # but the error message is very misleading
+        self._finalize_flag = False
 
     def _check_type(self, sys_to_be_added):
         if not issubclass(sys_to_be_added.__class__, self.allowed_sys_types):
@@ -131,6 +134,8 @@ class BaseSystemCollection(MutableSequence):
 
         """
 
+        assert self._finalize_flag is not True, "The finalize cannot be called twice."
+
         # FIXME: This is probably the most bizarre way to collect the functions. It is definitely
         # impressive and even surprising that it is working, but it is far from readable and maintainable.
         # The code is difficult to debug, because the behavior is un-interpretable except during run-time.
@@ -160,6 +165,8 @@ class BaseSystemCollection(MutableSequence):
 
         for finalize in finalize_methods:
             finalize(self)
+
+        self._finalize_flag = True
 
     def synchronize(self, time):
         # Calls all , connections, controls etc.

--- a/elastica/wrappers/base_system.py
+++ b/elastica/wrappers/base_system.py
@@ -41,12 +41,12 @@ class BaseSystemCollection(MutableSequence):
     """
 
     # Collection of functions. Each group is executed as a collection at the different steps.
-    # Each component (Forcing, Connection, etc.) registers the executable (callable) function 
+    # Each component (Forcing, Connection, etc.) registers the executable (callable) function
     # in the group that that needs to be executed.
-    _feature_group_synchronize: Iterable[Callable[[float],None]] = []
-    _feature_group_constrain_values: Iterable[Callable[[float],None]] = []
-    _feature_group_constrain_rates: Iterable[Callable[[float],None]] = []
-    _feature_group_callback: Iterable[Callable[[float,int,AnyStr],None]] = []
+    _feature_group_synchronize: Iterable[Callable[[float], None]] = []
+    _feature_group_constrain_values: Iterable[Callable[[float], None]] = []
+    _feature_group_constrain_rates: Iterable[Callable[[float], None]] = []
+    _feature_group_callback: Iterable[Callable[[float, int, AnyStr], None]] = []
     _feature_group_finalize: Iterable[Callable] = []
 
     def __init__(self):
@@ -152,22 +152,22 @@ class BaseSystemCollection(MutableSequence):
         # Toggle the finalize_flag
         self._finalize_flag = True
 
-    def synchronize(self, time:float):
+    def synchronize(self, time: float):
         # Collection call _featuer_group_synchronize
         for feature in self._feature_group_synchronize:
             feature(time)
 
-    def constrain_values(self, time:float):
+    def constrain_values(self, time: float):
         # Collection call _feature_group_constrain_values
         for feature in self._feature_group_constrain_values:
             feature(time)
 
-    def constrain_rates(self, time:float):
+    def constrain_rates(self, time: float):
         # Collection call _feature_group_constrain_rates
         for feature in self._feature_group_constrain_rates:
             feature(time)
 
-    def apply_callbacks(self, time:float, current_step: int):
+    def apply_callbacks(self, time: float, current_step: int):
         # Collection call _feature_group_callback
         for feature in self._feature_group_callback:
             feature(time, current_step)

--- a/elastica/wrappers/base_system.py
+++ b/elastica/wrappers/base_system.py
@@ -5,6 +5,8 @@ Base System
 Basic coordinating for multiple, smaller systems that have an independently integrable
 interface (i.e. works with symplectic or explicit routines `timestepper.py`.)
 """
+from typing import Iterable, Callable, AnyStr
+
 from collections.abc import MutableSequence
 from itertools import chain
 
@@ -25,8 +27,6 @@ class BaseSystemCollection(MutableSequence):
             Tuple of allowed type rod-like objects. Here use a base class for objects, i.e. RodBase.
         _systems: list
             List of rod-like objects.
-        _features: list
-            List of classes acting on the rod-like object, such as external forces classes.
 
     """
 
@@ -40,6 +40,15 @@ class BaseSystemCollection(MutableSequence):
     https://stackoverflow.com/q/3945940
     """
 
+    # Collection of functions. Each group is executed as a collection at the different steps.
+    # Each component (Forcing, Connection, etc.) registers the executable (callable) function 
+    # in the group that that needs to be executed.
+    _feature_group_synchronize: Iterable[Callable[[float],None]] = []
+    _feature_group_constrain_values: Iterable[Callable[[float],None]] = []
+    _feature_group_constrain_rates: Iterable[Callable[[float],None]] = []
+    _feature_group_callback: Iterable[Callable[[float,int,AnyStr],None]] = []
+    _feature_group_finalize: Iterable[Callable] = []
+
     def __init__(self):
         # We need to initialize our mixin classes
         super(BaseSystemCollection, self).__init__()
@@ -47,15 +56,11 @@ class BaseSystemCollection(MutableSequence):
         self.allowed_sys_types = (RodBase, RigidBodyBase)
         # List of systems to be integrated
         self._systems = []
-        # List of feature calls, such as those coming
-        # from Controllers, Environments which are
-        # tacked on to the SystemCollection in a sim.
-        self._features = NotImplemented
         # Flag Finalize: Finalizing twice will cause an error,
         # but the error message is very misleading
         self._finalize_flag = False
 
-    def _check_type(self, sys_to_be_added):
+    def _check_type(self, sys_to_be_added: AnyStr):
         if not issubclass(sys_to_be_added.__class__, self.allowed_sys_types):
             raise TypeError(
                 "{0}\n"
@@ -128,62 +133,41 @@ class BaseSystemCollection(MutableSequence):
         all rod-like objects to the simulator as well as all boundary conditions, callbacks, etc.,
         acting on these rod-like objects. After the finalize method called,
         the user cannot add new features to the simulator class.
-
-        Returns
-        -------
-
         """
 
+        # This generates more straight-forward error.
         assert self._finalize_flag is not True, "The finalize cannot be called twice."
-
-        # FIXME: This is probably the most bizarre way to collect the functions. It is definitely
-        # impressive and even surprising that it is working, but it is far from readable and maintainable.
-        # The code is difficult to debug, because the behavior is un-interpretable except during run-time.
-        # We need a lot more documentation on this part: clear explanation and reasoning.
-        def get_methods_from_feature_classes(method_name: str):
-            methods = [
-                [v for (k, v) in cls.__dict__.items() if k.endswith(method_name)]
-                for cls in self.__class__.__bases__
-            ]
-            return list(chain.from_iterable(methods))
-
-        self._features = get_methods_from_feature_classes("__call__")
-
-        self._features_that_constrain_values = get_methods_from_feature_classes(
-            "_constrain_values"
-        )
-        self._features_that_constrain_rates = get_methods_from_feature_classes(
-            "_constrain_rates"
-        )
-        self._callback_features = get_methods_from_feature_classes(
-            "_callback_execution"
-        )
-        finalize_methods = get_methods_from_feature_classes("_finalize")
 
         # construct memory block
         self._memory_blocks = construct_memory_block_structures(self._systems)
 
-        for finalize in finalize_methods:
-            finalize(self)
+        # Recurrent call finalize functions for all components.
+        for finalize in self._feature_group_finalize:
+            finalize()
 
+        # Clear the finalize feature group, just for the safety.
+        self._feature_group_finalize.clear()
+        self._feature_group_finalize = None
+
+        # Toggle the finalize_flag
         self._finalize_flag = True
 
-    def synchronize(self, time):
-        # Calls all , connections, controls etc.
-        for feature in self._features:
-            feature(self, time)
+    def synchronize(self, time:float):
+        # Collection call _featuer_group_synchronize
+        for feature in self._feature_group_synchronize:
+            feature(time)
 
-    def constrain_values(self, time):
-        # Calls all constraints, connections, controls etc.
-        for feature in self._features_that_constrain_values:
-            feature(self, time)
+    def constrain_values(self, time:float):
+        # Collection call _feature_group_constrain_values
+        for feature in self._feature_group_constrain_values:
+            feature(time)
 
-    def constrain_rates(self, time):
-        # Calls all constraints, connections, controls etc.
-        for feature in self._features_that_constrain_rates:
-            feature(self, time)
+    def constrain_rates(self, time:float):
+        # Collection call _feature_group_constrain_rates
+        for feature in self._feature_group_constrain_rates:
+            feature(time)
 
-    def apply_callbacks(self, time, current_step: int):
-        # Calls call back functions at the end of time-step
-        for feature in self._callback_features:
-            feature(self, time, current_step)
+    def apply_callbacks(self, time:float, current_step: int):
+        # Collection call _feature_group_callback
+        for feature in self._feature_group_callback:
+            feature(time, current_step)

--- a/elastica/wrappers/callbacks.py
+++ b/elastica/wrappers/callbacks.py
@@ -23,6 +23,8 @@ class CallBacks:
     def __init__(self):
         self._callback_list = []
         super(CallBacks, self).__init__()
+        self._feature_group_callback.append(self._callback_execution)
+        self._feature_group_finalize.append(self._finalize_callback)
 
     def collect_diagnostics(self, system):
         """
@@ -47,7 +49,7 @@ class CallBacks:
 
         return _callbacks
 
-    def _finalize(self):
+    def _finalize_callback(self):
         # From stored _CallBack objects, instantiate the boundary conditions
         # inplace : https://stackoverflow.com/a/1208792
 

--- a/elastica/wrappers/connections.py
+++ b/elastica/wrappers/connections.py
@@ -24,6 +24,8 @@ class Connections:
     def __init__(self):
         self._connections = []
         super(Connections, self).__init__()
+        self._feature_group_synchronize.append(self._call_connections)
+        self._feature_group_finalize.append(self._finalize_connections)
 
     def connect(
         self, first_rod, second_rod, first_connect_idx=None, second_connect_idx=None
@@ -64,7 +66,7 @@ class Connections:
 
         return _connector
 
-    def _finalize(self):
+    def _finalize_connections(self):
         # From stored _Connect objects, instantiate the joints and store it
 
         # dev : the first indices stores the
@@ -80,7 +82,7 @@ class Connections:
         # This is to optimize the call tree for better memory accesses
         # https://brooksandrew.github.io/simpleblog/articles/intro-to-graph-optimization-solving-cpp/
 
-    def __call__(self, *args, **kwargs):
+    def _call_connections(self, *args, **kwargs):
         for (
             first_sys_idx,
             second_sys_idx,

--- a/elastica/wrappers/constraints.py
+++ b/elastica/wrappers/constraints.py
@@ -24,6 +24,9 @@ class Constraints:
     def __init__(self):
         self._constraints = []
         super(Constraints, self).__init__()
+        self._feature_group_constrain_values.append(self._constrain_values)
+        self._feature_group_constrain_rates.append(self._constrain_rates)
+        self._feature_group_finalize.append(self._finalize_constraints)
 
     def constrain(self, system):
         """
@@ -48,7 +51,7 @@ class Constraints:
 
         return _constraint
 
-    def _finalize(self):
+    def _finalize_constraints(self):
         # From stored _Constraint objects, instantiate the boundary conditions
         # inplace : https://stackoverflow.com/a/1208792
 

--- a/elastica/wrappers/forcing.py
+++ b/elastica/wrappers/forcing.py
@@ -23,6 +23,8 @@ class Forcing:
     def __init__(self):
         self._ext_forces_torques = []
         super(Forcing, self).__init__()
+        self._feature_group_synchronize.append(self._call_ext_forces_torques)
+        self._feature_group_finalize.append(self._finalize_forcing)
 
     def add_forcing_to(self, system):
         """
@@ -47,7 +49,7 @@ class Forcing:
 
         return _ext_force_torque
 
-    def _finalize(self):
+    def _finalize_forcing(self):
         # From stored _ExtForceTorque objects, and instantiate a Force
         # inplace : https://stackoverflow.com/a/1208792
 
@@ -78,7 +80,7 @@ class Forcing:
         for index in friction_plane_index:
             self._ext_forces_torques.append(self._ext_forces_torques.pop(index))
 
-    def __call__(self, time, *args, **kwargs):
+    def _call_ext_forces_torques(self, time, *args, **kwargs):
         for sys_id, ext_force_torque in self._ext_forces_torques:
             ext_force_torque.apply_forces(self._systems[sys_id], time, *args, **kwargs)
             ext_force_torque.apply_torques(self._systems[sys_id], time, *args, **kwargs)

--- a/tests/test_wrappers/test_callbacks.py
+++ b/tests/test_wrappers/test_callbacks.py
@@ -163,7 +163,7 @@ class TestCallBacksMixin:
     def test_callback_finalize_correctness(self, load_rod_with_callbacks):
         scwc, callback_cls = load_rod_with_callbacks
 
-        scwc._finalize()
+        scwc._finalize_callback()
 
         for (x, y) in scwc._callback_list:
             assert type(x) is int
@@ -173,7 +173,7 @@ class TestCallBacksMixin:
     def test_callback_finalize_sorted(self, load_rod_with_callbacks):
         scwc, callback_cls = load_rod_with_callbacks
 
-        scwc._finalize()
+        scwc._finalize_callback()
 
         # this is allowed to fail (not critical)
         num = -np.inf

--- a/tests/test_wrappers/test_connections.py
+++ b/tests/test_wrappers/test_connections.py
@@ -324,7 +324,7 @@ class TestConnectionsMixin:
     def test_connect_finalize_correctness(self, load_rod_with_connects):
         scwc, connect_cls = load_rod_with_connects
 
-        scwc._finalize()
+        scwc._finalize_connections()
 
         for (fidx, sidx, fconnect, sconnect, connect) in scwc._connections:
             assert type(fidx) is int

--- a/tests/test_wrappers/test_constraints.py
+++ b/tests/test_wrappers/test_constraints.py
@@ -316,7 +316,7 @@ class TestConstraintsMixin:
     def test_constrain_finalize_correctness(self, load_rod_with_constraints):
         scwc, bc_cls = load_rod_with_constraints
 
-        scwc._finalize()
+        scwc._finalize_constraints()
 
         for (x, y) in scwc._constraints:
             assert type(x) is int
@@ -324,7 +324,7 @@ class TestConstraintsMixin:
 
     def test_constraint_properties(self, load_rod_with_constraints):
         scwc, _ = load_rod_with_constraints
-        scwc._finalize()
+        scwc._finalize_constraints()
 
         for i in [0, 1, -1]:
             x, y = scwc._constraints[i]
@@ -342,7 +342,7 @@ class TestConstraintsMixin:
     def test_constrain_finalize_sorted(self, load_rod_with_constraints):
         scwc, bc_cls = load_rod_with_constraints
 
-        scwc._finalize()
+        scwc._finalize_constraints()
 
         # this is allowed to fail (not critical)
         num = -np.inf

--- a/tests/test_wrappers/test_forcing.py
+++ b/tests/test_wrappers/test_forcing.py
@@ -196,7 +196,7 @@ class TestForcingMixin:
         )
         scwf.add_forcing_to(1).using(MockForcing, 2, 42)  # index based forcing
 
-        scwf._finalize()
+        scwf._finalize_forcing()
 
         # Now check if the Anisotropic friction is the last forcing class
         assert isinstance(scwf._ext_forces_torques[-1][-1], AnisotropicFrictionalPlane)
@@ -204,7 +204,7 @@ class TestForcingMixin:
     def test_constrain_finalize_correctness(self, load_rod_with_forcings):
         scwf, forcing_cls = load_rod_with_forcings
 
-        scwf._finalize()
+        scwf._finalize_forcing()
 
         for (x, y) in scwf._ext_forces_torques:
             assert type(x) is int
@@ -214,7 +214,7 @@ class TestForcingMixin:
     def test_constrain_finalize_sorted(self, load_rod_with_forcings):
         scwf, forcing_cls = load_rod_with_forcings
 
-        scwf._finalize()
+        scwf._finalize_forcing()
 
         # this is allowed to fail (not critical)
         num = -np.inf


### PR DESCRIPTION
# Wrapper structure redesign

I'm trying to address the below comments. This patch tries to fix the code structure accordingly. I hope this change makes the `wrapper` easier to understand for newcomers, and makes the documentation process nicer. The functionality should not have changed (All the pytest passes), because I just reorganized the structure.

https://github.com/GazzolaLab/PyElastica/blob/dd1bff433e7789914939e11eb6db90cfd60eee71/elastica/wrappers/base_system.py#L134-L144

## Discussion

> Note: I'm gonna use the term `base` to refer `BaseSystemCollection`, and `components` to refer to others (`Forcing`, `Constraints`, etc).

We have a conflict of design in our code structure. Fundamentally, we want to adapt the _Mixin_ paradigm as such
```py
class Simulator(BaseSystemCollection, Constraints, Forcing):
    pass

simulator = Simulator()
```
This design allows us to add/remove different modules easily, as long as we maintain the interface between components well. I think the problem comes because of the way each component is implemented: they resemble an _inheritance_ structure too much. For example, they share a similar structure overall, such as having `_finalize`, `__call__`, private wrapper class, `using`, etc. However, they will override themselves if we combine them to make _Mixin_ class, and this overriding is not part of our design choice.

The conflict of using `Mixin` and `OOP-inheritance` together shows in different places.

### 1. `self` in calling instance method??

https://github.com/GazzolaLab/PyElastica/blob/dd1bff433e7789914939e11eb6db90cfd60eee71/elastica/wrappers/base_system.py#L161-L182

Here, the first parameter of `feature`, which is some function in each component, needs `self` in their first parameter. This means they are used as a _static method_, even they are _instance method_!!  This is because functions in components are overriding themselves, and we need to backtrace which `feature` we want to call. Any developer will need to stop here and figure out what is going on.

### 2. Reflection

https://github.com/GazzolaLab/PyElastica/blob/dd1bff433e7789914939e11eb6db90cfd60eee71/elastica/wrappers/base_system.py#L138-L143

Here, the function `get_methods_from_feature_classes` collect methods in components using string comparison. Similar to above, we are forced with this functionality not because we want to collect functions, which should be a simple job of what `super()` should be doing, but because we lost overridden methods. As a result, we lose the debuggability of the code after this point, and we need over usage of the reflection technique to correct it.

### 3. Missing Abstract/Base for component

We have components (`Forcing`, `Constraints`, `Connection`, `Callback`) that share similar properties as mentioned above, but we cannot have a single abstract function that enforces the structure. This is because we cannot call `super()` and backtrace the MRO of the class.

## New Structure Suggestion

I'm suggesting a simple solution: let's drop the inheritance (it is not inheriting anything anyway). The method `finalize` and `call` look similar in each component, but they essentially serve different purposes. We cannot rely on `super()` because the order of execution is not well-synchronized. Keeping the method name the same across the component is confusing, error-prone, and dangerous without a proper inheritant structure. Most importantly, I don't see it as necessary.

_Mixin_ is powerful when a functionality needs to be added in to existing class, just like how Django extend the functionality using _Mixin_. Lets just do that: each component provide new functionality.

### What are we doing in the `finalize()`?

Essentially, the way I see the key functionality of `finalize` step is to allocate different component-methods into `synchronize`, `constrain_values`, `constrain_rates`, `finalize`, and `apply_callbacks` group. The group of methods is executed at different parts of the time stepper. Below is the diagram.

<img width="974" alt="image" src="https://user-images.githubusercontent.com/3798023/156879794-3e3563ea-59d2-4323-818b-e4eb37c74348.png">

Previously, we rely on `get_methods_from_feature_classes` to draw the connection arrow (blue arrow). I changed it so that the connection arrow (blue arrow) is registered by each component. This reduces the need of using string-comparison to organize the method. Furthermore, it should be the extendable design of choice, in case we want to add another feature group.

### Rename \_\_call\_\_

This dunderscore function makes the class `Callable`, but I don't see why: we never call simulator itself. Furthermore, this is dangerous because `__call__` is overridden for each components, and we don't know which one is called. I'm renaming the method.

## Changes

- Add an error message when a user tries to finalize twice. A `finalize_flag` is added to detect additional finalize calls. Previously, calling finalize twice gave an error, but the error message was not so useful to detect.
- Modify the finalize and wrapper structure.
- Modify test cases

## Note

- The PR is ready for `update-0.2.2`, but I wouldn't mind pushing to `update-0.3.0` to test more.