### PR TITLE
[WIP] Update timestep values for the new damping module

### DIFF
--- a/examples/AxialStretchingCase/axial_stretching.py
+++ b/examples/AxialStretchingCase/axial_stretching.py
@@ -89,9 +89,12 @@ stretch_sim.add_forcing_to(stretchable_rod).using(
 )
 
 # add damping
-damping_constant = 1.0
 dl = base_length / n_elem
-dt = 0.01 * dl
+# old damping model (deprecated in v0.3.0) values
+# dt = 0.01 * dl
+# damping_constant = 1.0
+dt = 0.1 * dl
+damping_constant = 0.1
 stretch_sim.dampen(stretchable_rod).using(
     ExponentialDamper,
     damping_constant=damping_constant,

--- a/examples/Binder/2_Slithering_Snake.ipynb
+++ b/examples/Binder/2_Slithering_Snake.ipynb
@@ -134,7 +134,7 @@
    },
    "outputs": [],
    "source": [
-    "dt = 8.0e-6\n",
+    "dt = 1e-4\n",
     "snake_sim.dampen(shearable_rod).using(\n",
     "    ExponentialDamper,\n",
     "    damping_constant=nu,\n",
@@ -324,7 +324,7 @@
     "\n",
     "pp_list = defaultdict(list)\n",
     "snake_sim.collect_diagnostics(shearable_rod).using(\n",
-    "    ContinuumSnakeCallBack, step_skip=1000, callback_params=pp_list\n",
+    "    ContinuumSnakeCallBack, step_skip=100, callback_params=pp_list\n",
     ")\n",
     "print(\"Callback function added to the simulator\")"
    ]

--- a/examples/ContinuumFlagellaCase/continuum_flagella.py
+++ b/examples/ContinuumFlagellaCase/continuum_flagella.py
@@ -80,8 +80,11 @@ def run_flagella(
     )
 
     # add damping
-    damping_constant = 2.5
-    dt = 2.5e-5 * period
+    # old damping model (deprecated in v0.3.0) values
+    # damping_constant = 2.5
+    # dt = 2.5e-5 * period
+    damping_constant = 0.625
+    dt = 1e-4 * period
     flagella_sim.dampen(shearable_rod).using(
         ExponentialDamper,
         damping_constant=damping_constant,
@@ -130,7 +133,6 @@ def run_flagella(
     # timestepper = PEFRL()
 
     final_time = (10.0 + 0.01) * period
-    dt = 2.5e-5 * period
     total_steps = int(final_time / dt)
     print("Total steps", total_steps)
     integrate(timestepper, flagella_sim, final_time, total_steps)

--- a/examples/ContinuumSnakeCase/continuum_snake.py
+++ b/examples/ContinuumSnakeCase/continuum_snake.py
@@ -28,10 +28,6 @@ def run_snake(
     # Simulation parameters
     period = 2
     final_time = (11.0 + 0.01) * period
-    time_step = 8e-6
-    total_steps = int(final_time / time_step)
-    rendering_fps = 60
-    step_skip = int(1.0 / (rendering_fps * time_step))
 
     # setting up test params
     n_elem = 50
@@ -103,12 +99,20 @@ def run_snake(
     )
 
     # add damping
+    # old damping model (deprecated in v0.3.0) values
+    # damping_constant = 2e-3
+    # time_step = 8e-6
     damping_constant = 2e-3
+    time_step = 1e-4
     snake_sim.dampen(shearable_rod).using(
         ExponentialDamper,
         damping_constant=damping_constant,
         time_step=time_step,
     )
+
+    total_steps = int(final_time / time_step)
+    rendering_fps = 60
+    step_skip = int(1.0 / (rendering_fps * time_step))
 
     # Add call backs
     class ContinuumSnakeCallBack(CallBackBaseClass):

--- a/examples/ExperimentalCases/ParallelConnectionExample/parallel_connection_example.py
+++ b/examples/ExperimentalCases/ParallelConnectionExample/parallel_connection_example.py
@@ -133,8 +133,11 @@ for i in range(n_elem):
 
 
 # add damping
-damping_constant = 4e-2
-dt = 1e-5
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 4e-2
+# dt = 1e-5
+damping_constant = 4e-3
+dt = 1e-3
 parallel_connection_sim.dampen(rod_one).using(
     ExponentialDamper,
     damping_constant=damping_constant,
@@ -171,17 +174,17 @@ pp_list_rod2 = defaultdict(list)
 
 
 parallel_connection_sim.collect_diagnostics(rod_one).using(
-    ParallelConnecitonCallback, step_skip=1000, callback_params=pp_list_rod1
+    ParallelConnecitonCallback, step_skip=40, callback_params=pp_list_rod1
 )
 parallel_connection_sim.collect_diagnostics(rod_two).using(
-    ParallelConnecitonCallback, step_skip=1000, callback_params=pp_list_rod2
+    ParallelConnecitonCallback, step_skip=40, callback_params=pp_list_rod2
 )
 
 
 parallel_connection_sim.finalize()
 timestepper = PositionVerlet()
 
-final_time = 5.0
+final_time = 20.0
 dl = base_length / n_elem
 total_steps = int(final_time / dt)
 print("Total steps", total_steps)

--- a/examples/FrictionValidationCases/rolling_friction_initial_velocity.py
+++ b/examples/FrictionValidationCases/rolling_friction_initial_velocity.py
@@ -38,7 +38,7 @@ def simulate_rolling_friction_initial_velocity_with(IFactor=0.0):
     base_area = np.pi * base_radius ** 2
     mass = 1.0
     density = mass / (base_length * base_area)
-    nu = 1e-6
+    nu = 1e-6 / 2
     E = 1e9
     # For shear modulus of 2E/3
     poisson_ratio = 0.5
@@ -74,7 +74,7 @@ def simulate_rolling_friction_initial_velocity_with(IFactor=0.0):
     rolling_friction_initial_velocity_sim.constrain(shearable_rod).using(FreeBC)
 
     # Add damping
-    dt = 1e-6
+    dt = 1e-6 * 2
     rolling_friction_initial_velocity_sim.dampen(shearable_rod).using(
         ExponentialDamper,
         damping_constant=nu,

--- a/examples/JointCases/fixed_joint.py
+++ b/examples/JointCases/fixed_joint.py
@@ -91,8 +91,11 @@ fixed_joint_sim.add_forcing_to(rod2).using(
 )
 
 # add damping
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 0.4
+# dt = 1e-5
 damping_constant = 0.4
-dt = 1e-5
+dt = 1e-4
 fixed_joint_sim.dampen(rod1).using(
     ExponentialDamper,
     damping_constant=damping_constant,

--- a/examples/JointCases/hinge_joint.py
+++ b/examples/JointCases/hinge_joint.py
@@ -93,8 +93,11 @@ hinge_joint_sim.add_forcing_to(rod2).using(
 )
 
 # add damping
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 4e-3
+# dt = 1e-5
 damping_constant = 4e-3
-dt = 1e-5
+dt = 5e-5
 hinge_joint_sim.dampen(rod1).using(
     ExponentialDamper,
     damping_constant=damping_constant,
@@ -145,7 +148,6 @@ timestepper = PositionVerlet()
 
 final_time = 10
 dl = base_length / n_elem
-dt = 1e-5
 total_steps = int(final_time / dt)
 print("Total steps", total_steps)
 integrate(timestepper, hinge_joint_sim, final_time, total_steps)

--- a/examples/JointCases/spherical_joint.py
+++ b/examples/JointCases/spherical_joint.py
@@ -94,8 +94,11 @@ spherical_joint_sim.add_forcing_to(rod2).using(
 )
 
 # add damping
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 4e-3
+# dt = 1e-5
 damping_constant = 4e-3
-dt = 1e-5
+dt = 5e-5
 spherical_joint_sim.dampen(rod1).using(
     ExponentialDamper,
     damping_constant=damping_constant,
@@ -146,7 +149,6 @@ timestepper = PositionVerlet()
 
 final_time = 10
 dl = base_length / n_elem
-dt = 1e-5
 total_steps = int(final_time / dt)
 print("Total steps", total_steps)
 integrate(timestepper, spherical_joint_sim, final_time, total_steps)

--- a/examples/MuscularFlagella/muscular_flagella.py
+++ b/examples/MuscularFlagella/muscular_flagella.py
@@ -152,7 +152,7 @@ flagella_muscle = CosseratRod.straight_rod(
     base_length_muscle,
     base_radius_muscle,
     density_muscle,
-    nu_muscle,
+    0.0,  # internal damping constant, deprecated in v0.3.0
     E_muscle,
     shear_modulus=shear_modulus_muscle,
 )

--- a/examples/MuscularSnake/muscular_snake.py
+++ b/examples/MuscularSnake/muscular_snake.py
@@ -126,7 +126,7 @@ for i in range(int(n_muscle_fibers / 2)):
         base_length_muscle,
         muscle_radius,
         density_muscle,
-        nu_muscle,
+        0.0,  # internal damping constant, deprecated in v0.3.0
         youngs_modulus=E_muscle,
         shear_modulus=shear_modulus_muscle,
     )
@@ -191,7 +191,7 @@ for i in range(int(n_muscle_fibers / 2), n_muscle_fibers):
         base_length_muscle,
         muscle_radius,
         density_muscle,
-        nu_muscle,
+        0.0,  # internal damping constant, deprecated in v0.3.0
         youngs_modulus=E_muscle,
         shear_modulus=shear_modulus_muscle,
     )

--- a/examples/RodContactCase/RodRodContact/rod_rod_contact_inclined_validation.py
+++ b/examples/RodContactCase/RodRodContact/rod_rod_contact_inclined_validation.py
@@ -18,7 +18,9 @@ class InclinedRodRodContact(
 inclined_rod_rod_contact_sim = InclinedRodRodContact()
 
 # Simulation parameters
-dt = 5e-5
+# old damping model (deprecated in v0.3.0) values
+# dt = 5e-5
+dt = 2.5e-4
 final_time = 20
 total_steps = int(final_time / dt)
 time_step = np.float64(final_time / total_steps)
@@ -93,7 +95,9 @@ inclined_rod_rod_contact_sim.connect(rod_one, rod_two).using(
 )
 
 # add damping
-damping_constant = 2e-3
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 2e-3
+damping_constant = 4e-4
 inclined_rod_rod_contact_sim.dampen(rod_one).using(
     ExponentialDamper,
     damping_constant=damping_constant,

--- a/examples/RodContactCase/RodRodContact/rod_rod_contact_parallel_validation.py
+++ b/examples/RodContactCase/RodRodContact/rod_rod_contact_parallel_validation.py
@@ -18,7 +18,9 @@ class ParallelRodRodContact(
 parallel_rod_rod_contact_sim = ParallelRodRodContact()
 
 # Simulation parameters
-dt = 5e-5
+# old damping model (deprecated in v0.3.0) values
+# dt = 5e-5
+dt = 5e-4
 final_time = 10
 total_steps = int(final_time / dt)
 time_step = np.float64(final_time / total_steps)
@@ -90,7 +92,9 @@ parallel_rod_rod_contact_sim.connect(rod_one, rod_two).using(
 )
 
 # add damping
-damping_constant = 2e-3
+# old damping model (deprecated in v0.3.0) values
+# damping_constant = 2e-3
+damping_constant = 2e-4
 parallel_rod_rod_contact_sim.dampen(rod_one).using(
     ExponentialDamper,
     damping_constant=damping_constant,

--- a/examples/TimoshenkoBeamCase/convergence_timoshenko.py
+++ b/examples/TimoshenkoBeamCase/convergence_timoshenko.py
@@ -38,7 +38,7 @@ def simulate_timoshenko_beam_with(
     base_length = 3.0
     base_radius = 0.25
     density = 5000
-    nu = 0.1 / density / (np.pi * base_radius ** 2)
+    nu = 0.1 / 7 / density / (np.pi * base_radius ** 2)
     E = 1e6
     # For shear modulus of 1e4, nu is 99!
     poisson_ratio = 99
@@ -60,7 +60,7 @@ def simulate_timoshenko_beam_with(
     timoshenko_sim.append(shearable_rod)
     # add damping
     dl = base_length / n_elem
-    dt = 0.01 * dl
+    dt = 0.07 * dl
     timoshenko_sim.dampen(shearable_rod).using(
         ExponentialDamper,
         damping_constant=nu,

--- a/examples/TimoshenkoBeamCase/timoshenko.py
+++ b/examples/TimoshenkoBeamCase/timoshenko.py
@@ -34,7 +34,7 @@ base_length = 3.0
 base_radius = 0.25
 base_area = np.pi * base_radius ** 2
 density = 5000
-nu = 0.1 / density / base_area
+nu = 0.1 / 7 / density / base_area
 E = 1e6
 # For shear modulus of 1e4, nu is 99!
 poisson_ratio = 99
@@ -56,7 +56,7 @@ shearable_rod = CosseratRod.straight_rod(
 timoshenko_sim.append(shearable_rod)
 # add damping
 dl = base_length / n_elem
-dt = 0.01 * dl
+dt = 0.07 * dl
 timoshenko_sim.dampen(shearable_rod).using(
     ExponentialDamper,
     damping_constant=nu,


### PR DESCRIPTION
Fixes #118.

The example timestep values will be investigated (with help from @armantekinalp), along with confirmation, that the dynamics of the individual cases stay the same:

- [x] axial stretching - 10x larger timestep, with 10x smaller damping constant
- [x] binder stuff - for snake 12.5x larger timestep, with same damping constant, no change for timoshenko
- [x] ~~butterfly~~
- [x] continuum flagella - 4x larger timestep, with 4x smaller damping constant
- [x] continuum snake - 12.5x larger timestep, with same damping constant
- [x] Experimental cases - parallel connection - 100x larger timestep, with 10x smaller damping constant
- [x] ~~flexible swinging pendulum~~
- [x] friction validation cases - 2 times larger time-step, 2 times smaller damping constant
- [x] helical buckling - No improvement.
- [x] joint cases - 5-10x larger timestep, with same damping constant
- [x] muscular flagella - No change. For larger timesteps, it is unstable with the same damping constant
- [x] muscular snake - No change. For larger timesteps, it is unstable with the same damping constant
- [x] ~~restart example~~
- [x] rod-rod contact cases - 5-10x larger timestep, with 5-10x smaller damping constant
- [x] rod self contact cases - No improvement
- [x] timoshenko - 7x larger tilmestep, with 7x smaller damping constant