### PR TITLE
Fix #128:  save_every condition in ExportCallBack

### DIFF
--- a/.github/workflows/wip_PR
+++ b/.github/workflows/wip_PR
@@ -1,0 +1,14 @@
+name: WIP
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  wip:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: wip/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/elastica/callback_functions.py
+++ b/elastica/callback_functions.py
@@ -155,7 +155,6 @@ class ExportCallBack(CallBackBaseClass):
 
         self.buffer = defaultdict(list)
         self.buffer_size = 0
-        self.steps_since_last_save: int = 0
 
         # Module
         if method == ExportCallBack.AVAILABLE_METHOD[0]:
@@ -185,7 +184,6 @@ class ExportCallBack(CallBackBaseClass):
         current_step : int
             simulation step
         """
-        self.steps_since_last_save += 1
 
         if current_step % self.step_skip == 0:
             position = system.position_collection.copy()
@@ -204,11 +202,11 @@ class ExportCallBack(CallBackBaseClass):
                 + sys.getsizeof(director)
             )
 
-            if (
-                self.buffer_size > ExportCallBack.FILE_SIZE_CUTOFF
-                or self.steps_since_last_save >= self.save_every
-            ):
-                self._dump()
+        if (
+            self.buffer_size > ExportCallBack.FILE_SIZE_CUTOFF
+            or (current_step + 1) % self.save_every == 0
+        ):
+            self._dump()
 
     def _dump(self, **kwargs):
         file_path = f"{self.save_path}_{self.file_count}.dat"
@@ -226,6 +224,5 @@ class ExportCallBack(CallBackBaseClass):
             self._pickle.dump(data, file)
 
         self.file_count += 1
-        self.steps_since_last_save = 0
         self.buffer_size = 0
         self.buffer.clear()

--- a/elastica/callback_functions.py
+++ b/elastica/callback_functions.py
@@ -155,6 +155,7 @@ class ExportCallBack(CallBackBaseClass):
 
         self.buffer = defaultdict(list)
         self.buffer_size = 0
+        self.steps_since_last_save: int = 0
 
         # Module
         if method == ExportCallBack.AVAILABLE_METHOD[0]:
@@ -184,6 +185,8 @@ class ExportCallBack(CallBackBaseClass):
         current_step : int
             simulation step
         """
+        self.steps_since_last_save += 1
+
         if current_step % self.step_skip == 0:
             position = system.position_collection.copy()
             velocity = system.velocity_collection.copy()
@@ -200,9 +203,10 @@ class ExportCallBack(CallBackBaseClass):
                 + sys.getsizeof(velocity)
                 + sys.getsizeof(director)
             )
+
             if (
                 self.buffer_size > ExportCallBack.FILE_SIZE_CUTOFF
-                or (current_step + 1) % self.save_every == 0
+                or self.steps_since_last_save >= self.save_every
             ):
                 self._dump()
 
@@ -222,5 +226,6 @@ class ExportCallBack(CallBackBaseClass):
             self._pickle.dump(data, file)
 
         self.file_count += 1
+        self.steps_since_last_save = 0
         self.buffer_size = 0
         self.buffer.clear()

--- a/elastica/callback_functions.py
+++ b/elastica/callback_functions.py
@@ -184,7 +184,6 @@ class ExportCallBack(CallBackBaseClass):
         current_step : int
             simulation step
         """
-
         if current_step % self.step_skip == 0:
             position = system.position_collection.copy()
             velocity = system.velocity_collection.copy()


### PR DESCRIPTION
The previous implementation would require "skip_step" and "save_every" to be synchronous in order to trigger. Now, we instead count the number of time steps since the last save and trigger the save whenever this number is higher or equal than the "save_every" parameter