### PR TITLE
Fix bug in checking of path for ExportCallback

### DIFF
--- a/elastica/callback_functions.py
+++ b/elastica/callback_functions.py
@@ -141,7 +141,7 @@ class ExportCallBack(CallBackBaseClass):
         assert (
             method in ExportCallBack.AVAILABLE_METHOD
         ), f"The exporting method ({method}) is not supported. Please use one of {ExportCallBack.AVAILABLE_METHOD}."
-        assert os.path.exists(path), "The export path does not exist."
+        assert os.path.exists(os.path.dirname(path)), "The export path does not exist."
 
         # Argument Parameters
         self.step_skip = step_skip


### PR DESCRIPTION
If any path not equal to a directory is specified, the current implementation throws an error that the export path does not exist. However, it should also be possible to use filenames (instead of just dirnames) such as:
```python
path="dirname/filename"
```
and then the first batch of data should be for example saved as `dirname/filename_0.dat.npz`.