### PR TITLE
Fix #142 by adjusting data structure of `fixed_positions` and `fixed_directors`

### DIFF
--- a/elastica/boundary_conditions.py
+++ b/elastica/boundary_conditions.py
@@ -308,8 +308,20 @@ class FixedConstraint(ConstraintBase):
             else:
                 # TODO: This part is prone to error.
                 break
-        self.fixed_positions = np.array(pos)
-        self.fixed_directors = np.array(dir)
+
+        if len(pos) > 0:
+            # transpose from (blocksize, dim) to (dim, blocksize)
+            self.fixed_positions = np.array(pos).transpose((1, 0))
+        else:
+            # initialize empty fixed positions
+            self.fixed_positions = np.zeros((3, 0))
+
+        if len(dir) > 0:
+            # transpose from (blocksize, dim, dim) to (dim, dim, blocksize)
+            self.fixed_directors = np.array(dir).transpose((1, 2, 0))
+        else:
+            # initialize empty fixed directors
+            self.fixed_directors = np.zeros((3, 3, 0))
 
     def constrain_values(
         self, rod: Union[Type[RodBase], Type[RigidBodyBase]], time: float
@@ -362,7 +374,7 @@ class FixedConstraint(ConstraintBase):
         block_size = indices.size
         for i in range(block_size):
             k = indices[i]
-            director_collection[..., k] = fixed_director_collection[i, ...]
+            director_collection[..., k] = fixed_director_collection[..., i]
 
     @staticmethod
     @njit(cache=True)
@@ -385,9 +397,7 @@ class FixedConstraint(ConstraintBase):
         block_size = indices.size
         for i in range(block_size):
             k = indices[i]
-            position_collection[0, k] = fixed_position_collection[i, 0]
-            position_collection[1, k] = fixed_position_collection[i, 1]
-            position_collection[2, k] = fixed_position_collection[i, 2]
+            position_collection[..., k] = fixed_position_collection[..., i]
 
     @staticmethod
     @njit(cache=True)
@@ -406,9 +416,7 @@ class FixedConstraint(ConstraintBase):
         block_size = indices.size
         for i in range(block_size):
             k = indices[i]
-            velocity_collection[0, k] = 0.0
-            velocity_collection[1, k] = 0.0
-            velocity_collection[2, k] = 0.0
+            velocity_collection[..., k] = 0.0
 
     @staticmethod
     @njit(cache=True)
@@ -427,9 +435,7 @@ class FixedConstraint(ConstraintBase):
         block_size = indices.size
         for i in range(block_size):
             k = indices[i]
-            omega_collection[0, k] = 0.0
-            omega_collection[1, k] = 0.0
-            omega_collection[2, k] = 0.0
+            omega_collection[..., k] = 0.0
 
 
 class HelicalBucklingBC(ConstraintBase):


### PR DESCRIPTION
Fixes #142 by implementing the following changes:

- Tranpose `fixed_positions` and `fixed_directors` after initialization to mirror the standard data structure in `pyelastica`, which is batch-last as in `(dim, batch)` or `(dim, dim,batch)`
- Simplify code by using `...` for slicing of vector entries instead of listing each dim separately