### PR TITLE
#37: Add `control` mixin and `Controller` interface

### DIFF
--- a/docs/api/controllers.rst
+++ b/docs/api/controllers.rst
@@ -1,0 +1,35 @@
+Controllers
+==============================
+
+.. _controllers:
+
+
+Description
+-----------
+
+Interfaces for controllers applying forces and torques to systems as a function of the state of one or multiple systems.
+
+.. rubric:: Available Controllers
+
+.. automodule:: elastica.controllers
+.. autosummary::
+   :nosignatures:
+
+   ControllerBase
+
+Compatibility
+~~~~~~~~~~~~~
+
+========================== ======= ============
+Controller                  Rod     Rigid Body
+========================== ======= ============
+ControllerBase              ✅      ✅
+========================== ======= ============
+
+Built-in Controllers
+------------------------
+.. automodule:: elastica.controllers
+   :noindex:
+
+.. autoclass:: ControllerBase
+   :special-members: __init__

--- a/docs/guide/workflow.md
+++ b/docs/guide/workflow.md
@@ -40,6 +40,7 @@ Available components are:
 | [Connections](../api/connections.rst) |                                 |
 |   [CallBacks](../api/callback.rst)    |                                 |
 |     [Damping](../api/damping.rst)     |                                 |
+|   [Control](../api/controllers.rst)   |                                 |
 
 :::{Note}
 We adopted a composition and mixin design paradigm in building elastica. The detail of the implementation is not important in using the package, but we left some references to read [here](../advanced/PackageDesign.md).

--- a/elastica/__init__.py
+++ b/elastica/__init__.py
@@ -13,3 +13,4 @@ from elastica.timestepper import *
 from elastica.restart import *
 from elastica.reset_functions_for_block_structure import *
 from elastica.typing import *
+from elastica.controllers import *

--- a/elastica/controllers.py
+++ b/elastica/controllers.py
@@ -1,0 +1,59 @@
+from elastica.typing import SystemType
+import numpy as np
+from typing import Dict
+
+
+class ControllerBase:
+    """
+       This is the base class for controllers acting on one or multiple systems.
+
+       Notes
+       -----
+       Every new controller class must be derived
+       from the ControllerBase class.
+
+       """
+
+    def __init__(self):
+        """
+        ControllerBase class does not need any input parameters.
+        """
+        pass
+
+    def apply_forces(self, systems: Dict[str, SystemType], time: np.float64 = 0.0):
+        """Apply forces to a system object.
+
+        In ControllerBase class, this routine simply passes.
+
+        Parameters
+        ----------
+        systems : Dict[str, SystemType]
+             Dictionary of system objects.
+        time : float
+            The time of simulation.
+
+        Returns
+        -------
+
+
+        """
+
+        pass
+
+    def apply_torques(self, systems: Dict[str, SystemType], time: np.float64 = 0.0):
+        """Apply torques to a system object.
+
+        In ControllerBase class, this routine simply passes.
+
+        Parameters
+        ----------
+        systems : Dict[str, SystemType]
+            Dictionary of system objects.
+        time : float
+            The time of simulation.
+
+        Returns
+        -------
+
+        """
+        pass

--- a/elastica/controllers.py
+++ b/elastica/controllers.py
@@ -5,14 +5,14 @@ from typing import Dict
 
 class ControllerBase:
     """
-       This is the base class for controllers acting on one or multiple systems.
+    This is the base class for controllers acting on one or multiple systems.
 
-       Notes
-       -----
-       Every new controller class must be derived
-       from the ControllerBase class.
+    Notes
+    -----
+    Every new controller class must be derived
+    from the ControllerBase class.
 
-       """
+    """
 
     def __init__(self):
         """

--- a/elastica/wrappers/__init__.py
+++ b/elastica/wrappers/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "Forcing",
     "CallBacks",
     "Damping",
+    "Control",
 ]
 from .base_system import BaseSystemCollection
 from .connections import Connections
@@ -18,3 +19,4 @@ from .constraints import Constraints
 from .forcing import Forcing
 from .callbacks import CallBacks
 from .damping import Damping
+from .control import Control

--- a/elastica/wrappers/control.py
+++ b/elastica/wrappers/control.py
@@ -66,7 +66,9 @@ class Control:
 
     def _call_controller(self, time, *args, **kwargs):
         for keys, sys_indices, controller in self._controllers:
-            systems = {key: self._systems[sys_idx] for key, sys_idx in zip(keys, sys_indices)}
+            systems = {
+                key: self._systems[sys_idx] for key, sys_idx in zip(keys, sys_indices)
+            }
             controller.apply_forces(systems=systems, time=time, *args, **kwargs)
             controller.apply_torques(systems=systems, time=time, *args, **kwargs)
 

--- a/elastica/wrappers/control.py
+++ b/elastica/wrappers/control.py
@@ -1,0 +1,160 @@
+__doc__ = """
+Control
+-------
+
+Provides the control interface to apply forces and torques to systems as a function of the state of the simulation.
+"""
+from elastica.typing import SystemType
+from typing import Dict, List
+
+
+class Control:
+    """
+    The Control class is a wrapper for applying boundary conditions that
+    consist of applied external forces. To apply forcing on system objects,
+    the simulator class must be derived from the Forcing class.
+
+        Attributes
+        ----------
+        _controllers: list
+            List of forcing class defined for rod-like objects.
+    """
+
+    def __init__(self):
+        self._controllers = []
+        super(Control, self).__init__()
+        self._feature_group_synchronize.append(self._call_controller)
+        self._feature_group_finalize.append(self._finalize_control)
+
+    def control(self, systems: Dict[str, SystemType]):
+        """
+        This method applies external forces and torques on the relevant
+        user-defined system or rod-like object. You must input the system
+        or rod-like object that you want to apply external forces and torques on.
+
+        Parameters
+        ----------
+        systems: Dict[SystemType]
+            Dict of system objects, whose state gets passed to the Controller class
+
+        Returns
+        -------
+
+        """
+        sys_indices = {}
+        for key, system in systems.items():
+            sys_idx = self._get_sys_idx_if_valid(system)
+            sys_indices[key] = sys_idx
+
+        # Create _Constraint object, cache it and return to user
+        controller = _Controller(sys_indices)
+        self._controllers.append(controller)
+
+        return controller
+
+    def _finalize_control(self):
+        # From stored _Controller objects, and instantiate a Controller object
+        # inplace : https://stackoverflow.com/a/1208792
+
+        # dev : the first index stores the rod index to apply the boundary condition
+        # to. Technically we can use another array but it its one more book-keeping
+        # step. Being lazy, I put them both in the same array
+        self._controllers[:] = [
+            (controller.ids().keys(), controller.ids().values(), controller())
+            for controller in self._controllers
+        ]
+
+    def _call_controller(self, time, *args, **kwargs):
+        for keys, sys_indices, controller in self._controllers:
+            systems = {key: self._systems[sys_idx] for key, sys_idx in zip(keys, sys_indices)}
+            controller.apply_forces(systems=systems, time=time, *args, **kwargs)
+            controller.apply_torques(systems=systems, time=time, *args, **kwargs)
+
+
+class _Controller:
+    """
+    Controller wrapper private class
+
+    Attributes
+    ----------
+    _sys_indices: Dict[str, int]
+    _control_cls: List[int]
+    *args
+        Variable length argument list.
+    **kwargs
+        Arbitrary keyword arguments.
+    """
+
+    def __init__(self, sys_indices: Dict[str, int]):
+        """
+
+        Parameters
+        ----------
+        sys_idx: int
+        """
+        self._sys_indices = sys_indices
+        self._controller_cls = None
+        self._args = ()
+        self._kwargs = {}
+
+    def using(self, controller_cls, *args, **kwargs):
+        """
+        This method is a wrapper to set which forcing class is used to apply forcing
+        to user defined rod-like objects.
+
+        Parameters
+        ----------
+        controller_cls: object
+            User defined controller class.
+        *args
+            Variable length argument list
+        **kwargs
+            Arbitrary keyword arguments.
+
+        Returns
+        -------
+
+        """
+        from elastica.controllers import ControllerBase
+
+        assert issubclass(
+            controller_cls, ControllerBase
+        ), "{} is not a valid controller. Did you forget to derive from ControllerBase?".format(
+            controller_cls
+        )
+        self._controller_cls = controller_cls
+        self._args = args
+        self._kwargs = kwargs
+        return self
+
+    def ids(self):
+        return self._sys_indices
+
+    def __call__(self, *args, **kwargs):
+        """Constructs a controller after checks
+
+        Parameters
+        ----------
+        *args
+            Variable length argument list.
+        **kwargs
+            Arbitrary keyword arguments.
+
+        Returns
+        -------
+
+        """
+        if not self._controller_cls:
+            raise RuntimeError(
+                "No controller provided to act on system ids {0}"
+                "but a force was registered. Did you forget to call"
+                "the `using` method".format(self.ids().values())
+            )
+
+        try:
+            return self._controller_cls(*self._args, **self._kwargs)
+        except (TypeError, IndexError):
+            raise TypeError(
+                r"Unable to construct forcing class.\n"
+                r"Did you provide all necessary controller properties?"
+            )

--- a/examples/ControllerCases/pendulum_tracking_sphere.py
+++ b/examples/ControllerCases/pendulum_tracking_sphere.py
@@ -82,7 +82,9 @@ class PendulumTrackingController(ControllerBase):
         # current rotation angle of the sphere around the z-axis
         sphere_theta = np.arctan2(sphere_position[1], sphere_position[0])
 
-        pendulum_tip_local_frame = np.array([0.0, 0.0, systems["pendulum"].length.item() / 2])
+        pendulum_tip_local_frame = np.array(
+            [0.0, 0.0, systems["pendulum"].length.item() / 2]
+        )
         # compute tip position of pendulum in inertial frame
         pendulum_tip = (
             systems["pendulum"].director_collection[..., 0].T @ pendulum_tip_local_frame

--- a/examples/ControllerCases/pendulum_tracking_sphere.py
+++ b/examples/ControllerCases/pendulum_tracking_sphere.py
@@ -82,7 +82,7 @@ class PendulumTrackingController(ControllerBase):
         # current rotation angle of the sphere around the z-axis
         sphere_theta = np.arctan2(sphere_position[1], sphere_position[0])
 
-        pendulum_tip_local_frame = np.array([0, 0.0, systems["pendulum"].length / 2])
+        pendulum_tip_local_frame = np.array([0.0, 0.0, systems["pendulum"].length.item() / 2])
         # compute tip position of pendulum in inertial frame
         pendulum_tip = (
             systems["pendulum"].director_collection[..., 0].T @ pendulum_tip_local_frame
@@ -99,7 +99,11 @@ class PendulumTrackingController(ControllerBase):
         )
 
         # compute torque with PID controller
-        torsional_torque = self.P * error_theta + self.I * self.integrator - self.D * angular_velocity[2]
+        torsional_torque = (
+            self.P * error_theta
+            + self.I * self.integrator
+            - self.D * angular_velocity[2]
+        )
 
         # compute torque in inertial frame
         torque_lab_frame = torsional_torque * np.array([0.0, 0.0, 1.0])
@@ -166,8 +170,8 @@ control_simulator.control(systems={"pendulum": pendulum, "sphere": sphere}).usin
     PendulumTrackingController,
     dt=dt,
     P=1e-3,
-    I=5e-4,
-    D=5e-5,
+    I=2e-5,
+    D=2e-5,
 )
 
 pp_list_pendulum = defaultdict(list)

--- a/examples/ControllerCases/pendulum_tracking_sphere.py
+++ b/examples/ControllerCases/pendulum_tracking_sphere.py
@@ -1,0 +1,186 @@
+__doc__ = """Example where the tip of a pendulum is tracking a sphere."""
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+import sys
+
+# FIXME without appending sys.path make it more generic
+sys.path.append("../../")
+from elastica import *
+from examples.ControllerCases.pendulum_tracking_sphere_postprocessing import (
+    plot_video,
+    plot_video_xy,
+)
+
+
+class ControlSimulator(
+    BaseSystemCollection, Constraints, Connections, Forcing, CallBacks, Control
+):
+    pass
+
+
+class SphereCircularConstraint(ConstraintBase):
+    def __init__(self, *args, circle_radius: float, frequency: float, **kwargs):
+        """
+        Parameters
+        ----------
+        circle_radius : float
+            Radius of the circle which sphere is tracking.
+        frequency : float
+            Rotational frequency [Hz] of the sphere moving around the circle.
+        """
+        super(SphereCircularConstraint, self).__init__(*args, **kwargs)
+        self.circle_radius = circle_radius
+        self.frequency = frequency
+
+    def constrain_values(self, system: SystemType, time: float):
+        # reset position values on z-axis
+        system.position_collection[2, :] = 0.0
+
+        # desired rotation angle around y-axis at the current time step
+        theta = self.frequency * 2 * np.pi * time
+
+        # this assumes that for a zero theta angle, the pendulum is aligned with the x-axis.
+        system.position_collection[0, :] = np.cos(theta) * self.circle_radius
+        system.position_collection[1, :] = np.sin(theta) * self.circle_radius
+
+    def constrain_rates(self, system: SystemType, time: float) -> None:
+        """We directly correct the positional values instead of bothering with the velocities."""
+        pass
+
+
+class PendulumTrackingController(ControllerBase):
+    """
+    PID Controller to track the sphere as closely as possible with the end of the pendulum
+
+    Parameters
+    ----------
+    P : float
+        Proportional gain [Nm / rad]
+    I : float
+        Integral gain [Nm / rad / s].
+    D : float
+        Derivative gain. [Nm s / rad]
+    """
+
+    def __init__(self, P: float = 0.0, I: float = 0.0, D: float = 0.0):
+        super().__init__()
+        self.P = P  # proportional gain
+        self.I = I  # integral gain
+        self.D = D  # derivative gain
+
+    def apply_torques(self, systems: Dict[str, SystemType], time: np.float64 = 0.0):
+        # collect positions of the sphere and the pendulum
+        sphere_position = systems["sphere"].position_collection[:, 0]
+        # current rotation angle of the sphere around the z-axis
+        sphere_theta = np.arctan2(sphere_position[1], sphere_position[0])
+        print("sphere_theta:", sphere_theta)
+
+        pendulum_zyx_euler = Rotation.from_matrix(
+            systems["pendulum"].director_collection[..., 0].T
+        ).as_euler("zyx")
+        # current rotation angle of the pendulum around the z-axis
+        pendulum_theta = pendulum_zyx_euler[2]
+        print("pendulum_theta:", pendulum_theta)
+
+        # error angle between the desired theta (e.g. rotation of sphere) and the current theta of the pendulum
+        error_theta = sphere_theta - pendulum_theta
+
+        # compute torque with PID controller
+        torque = self.P * error_theta
+
+        print("torque:", torque)
+
+        # apply force in local y-dir to cause rotation of end of pendulum around z-axis
+        systems["pendulum"].external_forces[1, 0] = torque / (
+            systems["pendulum"].length / 2
+        )
+
+        print("force", systems["pendulum"].external_forces[:, 0])
+
+
+control_simulator = ControlSimulator()
+
+# setting up test params
+direction = np.array([1.0, 0.0, 0.0])
+normal = np.array([0.0, 1.0, 0.0])
+base_length = 0.2
+base_radius = 0.01
+density = 1000
+poisson_ratio = 0.5
+
+# setting up timestepper and video
+final_time = 1
+dt = 5e-5
+total_steps = int(final_time / dt)
+fps = 100  # frames per second of the video
+diagnostic_step_skip = int(1 / (fps * dt))
+
+# Create pendulum with cylinder
+pendulum = Cylinder(
+    start=np.zeros((3,)),
+    direction=direction,
+    normal=normal,
+    base_length=base_length,
+    base_radius=base_radius,
+    density=density,
+)
+control_simulator.append(pendulum)
+
+# Create sphere system
+sphere = Sphere(
+    center=base_length * direction, base_radius=base_radius, density=density
+)
+control_simulator.append(sphere)
+
+# Apply boundary conditions to pendulum at base: only allow yaw (e.g. rotation around z-axis)
+# control_simulator.constrain(pendulum).using(
+#     GeneralConstraint,
+#     constrained_position_idx=(0,),
+#     constrained_director_idx=(0,),
+#     translational_constraint_selector=np.array([True, True, True]),
+#     rotational_constraint_selector=np.array([True, True, False]),
+# )
+
+# Move sphere along a circle in the XY plane (e.g. rotate around z-axis)
+control_simulator.constrain(sphere).using(
+    SphereCircularConstraint, circle_radius=base_length, frequency=0.1
+)
+
+# add controller to pendulum
+control_simulator.control(systems={"pendulum": pendulum, "sphere": sphere}).using(
+    PendulumTrackingController,
+    P=1e0,
+)
+
+pp_list_pendulum = defaultdict(list)
+pp_list_sphere = defaultdict(list)
+
+control_simulator.collect_diagnostics(pendulum).using(
+    MyCallBack, step_skip=diagnostic_step_skip, callback_params=pp_list_pendulum
+)
+control_simulator.collect_diagnostics(sphere).using(
+    MyCallBack, step_skip=diagnostic_step_skip, callback_params=pp_list_sphere
+)
+
+control_simulator.finalize()
+timestepper = PositionVerlet()
+
+print("Total steps", total_steps)
+integrate(timestepper, control_simulator, final_time, total_steps)
+
+filename = "pendulum_tracking_sphere_example"
+plot_video(
+    plot_params_pendulum=pp_list_pendulum,
+    pendulum=pendulum,
+    plot_params_sphere=pp_list_sphere,
+    video_name=filename + ".mp4",
+    fps=fps,
+)
+plot_video_xy(
+    plot_params_pendulum=pp_list_pendulum,
+    pendulum=pendulum,
+    plot_params_sphere=pp_list_sphere,
+    video_name=filename + "_xy.mp4",
+    fps=fps,
+)

--- a/examples/ControllerCases/pendulum_tracking_sphere_postprocessing.py
+++ b/examples/ControllerCases/pendulum_tracking_sphere_postprocessing.py
@@ -1,0 +1,164 @@
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.colors import to_rgb
+from mpl_toolkits import mplot3d
+from scipy.spatial.transform import Rotation
+from typing import Dict
+
+from elastica.rigidbody import Cylinder
+from elastica._linalg import _batch_matvec
+
+
+def plot_video(
+    plot_params_pendulum: Dict,
+    pendulum: Cylinder,
+    plot_params_sphere: Dict,
+    video_name="pendulum_tracking_sphere_example.mp4",
+    fps=100,
+):  # (time step, x/y/z, node)
+    import matplotlib.animation as manimation
+
+    time = plot_params_pendulum["time"]
+    position_of_pendulum = np.array(plot_params_pendulum["position"])
+    director_of_pendulum = np.array(plot_params_pendulum["directors"])
+    position_of_sphere = np.array(plot_params_sphere["position"])
+
+    print("plot video")
+    FFMpegWriter = manimation.writers["ffmpeg"]
+    metadata = dict(title="Movie Test", artist="Matplotlib", comment="Movie support!")
+    writer = FFMpegWriter(fps=fps, metadata=metadata)
+    fig = plt.figure(figsize=(10, 8), frameon=True, dpi=150)
+    with writer.saving(fig, video_name, 100):
+        for time in range(1, len(time)):
+            fig.clf()
+            ax = plt.axes(projection="3d")  # fig.add_subplot(111)
+            ax.grid(b=True, which="minor", color="k", linestyle="--")
+            ax.grid(b=True, which="major", color="k", linestyle="-")
+
+            # plot pendulum center of mass
+            ax.plot(
+                position_of_pendulum[time, 0],
+                position_of_pendulum[time, 1],
+                position_of_pendulum[time, 2],
+                "or",
+                label="Pendulum CoM",
+            )
+
+            # plot pendulum axis
+            pendulum_axis_points = np.zeros((3, 10))
+            pendulum_axis_points[2, :] = np.linspace(
+                start=-pendulum.length.squeeze() / 2,
+                stop=pendulum.length.squeeze() / 2,
+                num=pendulum_axis_points.shape[1],
+            )
+            pendulum_director = director_of_pendulum[time, ...]
+            pendulum_director_batched = np.repeat(
+                pendulum_director, repeats=pendulum_axis_points.shape[1], axis=2
+            )
+            # rotate points into inertial frame
+            pendulum_axis_points = _batch_matvec(
+                pendulum_director_batched.transpose((1, 0, 2)),
+                pendulum_axis_points,
+            )
+            # add offset position of CoM
+            pendulum_axis_points += position_of_pendulum[time, ...]
+            ax.plot(
+                pendulum_axis_points[0, :],
+                pendulum_axis_points[1, :],
+                pendulum_axis_points[2, :],
+                c="r",
+                label="Pendulum",
+            )
+
+            ax.plot(
+                position_of_sphere[time, 0],
+                position_of_sphere[time, 1],
+                position_of_sphere[time, 2],
+                "x",
+                c=to_rgb("xkcd:bluish"),
+                label="Sphere",
+            )
+
+            ax.set_xlim(-0.25, 0.25)
+            ax.set_ylim(-0.25, 0.25)
+            ax.set_zlim(0.0, 0.1)
+            ax.set_xlabel("x [m]")
+            ax.set_ylabel("y [m]")
+            ax.set_zlabel("z [m]")
+            plt.legend()
+
+            writer.grab_frame()
+
+
+def plot_video_xy(
+    plot_params_pendulum: Dict,
+    pendulum: Cylinder,
+    plot_params_sphere: Dict,
+    video_name="pendulum_tracking_sphere_example_xy.mp4",
+    fps=100,
+):  # (time step, x/y/z, node)
+    import matplotlib.animation as manimation
+
+    time = plot_params_pendulum["time"]
+    position_of_pendulum = np.array(plot_params_pendulum["position"])
+    director_of_pendulum = np.array(plot_params_pendulum["directors"])
+    position_of_sphere = np.array(plot_params_sphere["position"])
+
+    print("plot video xy")
+    FFMpegWriter = manimation.writers["ffmpeg"]
+    metadata = dict(title="Movie Test", artist="Matplotlib", comment="Movie support!")
+    writer = FFMpegWriter(fps=fps, metadata=metadata)
+    fig = plt.figure()
+    plt.axis("equal")
+    with writer.saving(fig, video_name, 100):
+        for time in range(1, len(time)):
+            fig.clf()
+
+            # plot pendulum center of mass
+            plt.plot(
+                position_of_pendulum[time, 0],
+                position_of_pendulum[time, 1],
+                "or",
+                label="Pendulum CoM",
+            )
+
+            # plot pendulum axis
+            pendulum_axis_points = np.zeros((3, 10))
+            pendulum_axis_points[2, :] = np.linspace(
+                start=-pendulum.length.squeeze() / 2,
+                stop=pendulum.length.squeeze() / 2,
+                num=pendulum_axis_points.shape[1],
+            )
+            pendulum_director = director_of_pendulum[time, ...]
+            pendulum_director_batched = np.repeat(
+                pendulum_director, repeats=pendulum_axis_points.shape[1], axis=2
+            )
+            # rotate points into inertial frame
+            pendulum_axis_points = _batch_matvec(
+                pendulum_director_batched.transpose((1, 0, 2)),
+                pendulum_axis_points,
+            )
+            # add offset position of CoM
+            pendulum_axis_points += position_of_pendulum[time, ...]
+            plt.plot(
+                pendulum_axis_points[0, :],
+                pendulum_axis_points[1, :],
+                c="r",
+                label="Pendulum",
+            )
+
+            plt.plot(
+                position_of_sphere[time, 0],
+                position_of_sphere[time, 1],
+                "x",
+                c=to_rgb("xkcd:bluish"),
+                label="Sphere",
+            )
+
+            plt.xlim([-0.25, 0.25])
+            plt.ylim([-0.25, 0.25])
+            plt.xlabel("x [m]")
+            plt.ylabel("y [m]")
+            plt.legend()
+
+            writer.grab_frame()


### PR DESCRIPTION
## Motivation

Many usage cases of `PyElastica` involve prototyping controllers. Often that involves knowing the state of multiple systems or even the state of the entire simulator and use this state information to apply appropriate (external) forces and torques to the various systems to achieve a certain control task.

## Considered alternatives
Using the external `forcing` mixins is insufficient for these use-cases, as it only allows knowledge of one system state at a time and analogue only one system can be controlled at a time. To circumvent these issues, complex and custom workarounds would need to be applied involving multiprocessing or pointers to persistent memory of system objects.

## Usage
Devise a custom controller:

```py
from elastica.controllers import ControllerBase
from elastica.typing import SystemType

class CustomController(ControllerBase):
    def __init__(self, systems: Dict[str, SystemType], step_skip: int, *args, **kwargs):
        super().__init__(systems=systems, step_skip=step_skip, *args, **kwargs)

    def apply_forces(self, systems: Dict[str, SystemType], time: float):
        for system_name, system in systems.items():
            system.external_forces += np.ones(shape=system.external_forces.shape)

    def apply_torques(self, systems: Dict[str, SystemType], time: float):
        for system_name, system in systems.items():
            system.external_torques += np.ones(shape=system.external_torques.shape)
```

Apply controller to simulator:

```py
simulator.control(
        systems={"rod1": rod1, "rod2": rod2, "cylinder1": cylinder1}
).using(CustomController, step_skip=1000)
```

## Example
I added the example of a pendulum tracking a sphere to the `ControllerCases` in `pendulum_tracking_sphere.py`.
Here, we initialize a (planar) pendulum as a cylinder in `PyElastica`, which is only allowed to rotate around the z-axis. The pendulum can be actuated by applying a torque around the z-axis in the inertial frame to the pendulum. We additionally simulate a sphere. This sphere moves in a circular trajectory around the z-axis at a fixed angular velocity, which is unknown to the controller. Now, we construct the `PendulumTrackingController` as a PID controller tracking the movement of the sphere. We compute the error between the polar angle of the sphere with the polar angle of the pendulum to output a torque acting on the pendulum to track the sphere as closely as possible:

https://user-images.githubusercontent.com/2360366/181371579-cafebf2a-5eb1-4574-88da-168199873a8e.mp4

https://user-images.githubusercontent.com/2360366/181371586-73b7e5c8-b7bc-4209-a206-ce0719460056.mp4

This example nicely illustrates the functionality of the new `control` interface, as this control problem requires access to the state of two simulate systems to compute appropriate forces / torques.

## TODOs

- [ ] Add tests
- [x] Add example
- [x] Add documentation

## Related to:
#37 