### PR TITLE
update: matplotlib and ffmpeg dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ poetry-remove:
 install:
 	poetry install
 
+.PHONY: install_examples_dependencies
+install_examples_dependencies:
+	poetry install -E examples
+	# sadly pip ffmpeg doesnt work, hence we use conda for ffmpeg
+	conda install -c conda-forge ffmpeg
+
 .PHONY: install_with_new_dependency
 install_with_new_dependency:
 	poetry lock

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ More [advanced cases](#advanced-cases) are stored in separate repository with it
 In order to run examples, you will need to install additional dependencies.
 
 ```bash
-poetry install -E examples
+make install_examples_dependencies
 ```
 
 ## Case Examples
@@ -30,7 +30,7 @@ Examples can serve as a starting template for customized usages.
     * __Features__: CosseratRod, MuscleTorques, AnisotropicFrictionalPlane, Gravity, CMA Optimization
     * [MuscularSnake](./MuscularSnake)
       * __Purpose__: Example of [Parallel connection module](../elastica/experimental/connection_contact_joint/parallel_connection.py) and customized [Force module](./MuscularSnake/muscle_forces.py) to implement muscular snake.
-      * __Features__: MuscleForces(custom implemented) 
+      * __Features__: MuscleForces(custom implemented)
 * [ButterflyCase](./ButterflyCase)
     * __Purpose__: Demonstrate simple restoration with initial strain.
     * __Features__: CosseratRod
@@ -51,13 +51,13 @@ Examples can serve as a starting template for customized usages.
     * __Features__: HelicalBucklingBC
 * [ContinuumFlagellaCase](./ContinuumFlagellaCase)
     * __Purpose__: Demonstrate flagella modeling using PyElastica.
-    * __Features__: SlenderBodyTheory, MuscleTorques, 
+    * __Features__: SlenderBodyTheory, MuscleTorques,
     * [MuscularFlagella](./MuscularFlagella)
         * __Purpose__: Example of customizing [Joint module](./MuscularFlagella/connection_flagella.py) and [Force module](./MuscularFlagella/muscle_forces_flagella.py) to implement muscular flagella.
         * __Features__: MuscleForces(custom implemented)
 * [RodContactCase](./RodContactCase)
   * [RodRodContact](./RodContactCase/RodRodContact)
-    * __Purpose__: Demonstrates contact between two rods, for different initial conditions. 
+    * __Purpose__: Demonstrates contact between two rods, for different initial conditions.
     * __Features__: CosseratRod, ExternalContact
   * [RodSelfContact](./RodContactCase/RodSelfContact)
     * [PlectonemesCase](./RodContactCase/RodSelfContact/PlectonemesCase)

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,17 +16,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "babel"
@@ -173,7 +173,7 @@ name = "cycler"
 version = "0.11.0"
 description = "Composable style cycles"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -239,7 +239,7 @@ name = "fonttools"
 version = "4.34.4"
 description = "Tools to manipulate font files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -277,7 +277,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.19.5"
+version = "2.20.0"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = true
@@ -364,7 +364,7 @@ name = "kiwisolver"
 version = "1.4.4"
 description = "A fast implementation of the Cassowary constraint solver"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -413,7 +413,7 @@ name = "matplotlib"
 version = "3.5.2"
 description = "Python plotting package"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -582,7 +582,7 @@ name = "pillow"
 version = "9.2.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -772,7 +772,7 @@ name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
@@ -836,7 +836,7 @@ name = "setuptools-scm"
 version = "7.0.5"
 description = "the blessed package to manage your versions by scm tags"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -854,7 +854,7 @@ name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -1076,7 +1076,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -1089,22 +1089,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.15.1"
+version = "20.16.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 platformdirs = ">=2,<3"
-six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [[package]]
 name = "zipp"
@@ -1120,12 +1119,12 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [extras]
 docs = ["Sphinx", "sphinx-book-theme", "readthedocs-sphinx-search", "sphinx-autodoc-typehints", "myst-parser", "numpydoc", "docutils"]
-examples = ["cma", "ffmpeg", "moviepy"]
+examples = ["cma", "ffmpeg", "moviepy", "matplotlib"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "31633e99dda7371ff2385b3b76fdd2de124f09d6d7b7fb41243eb5de5e27a20d"
+content-hash = "1571e4eae9449362d7459c6a12769dd63dadc8dd6466310ffc6bfe3f05fc9ac3"
 
 [metadata.files]
 alabaster = [
@@ -1133,10 +1132,7 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 atomicwrites = []
-attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
-]
+attrs = []
 babel = []
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,14 +177,6 @@ optional = true
 python-versions = ">=3.6"
 
 [[package]]
-name = "decorator"
-version = "4.4.2"
-description = "Decorators for Humans"
-category = "main"
-optional = true
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-
-[[package]]
 name = "distlib"
 version = "0.3.5"
 description = "Distribution utilities"
@@ -199,14 +191,6 @@ description = "Docutils -- Python Documentation Utilities"
 category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "ffmpeg"
-version = "1.4"
-description = "ffmpeg python package url [https://github.com/jiashaokun/ffmpeg]"
-category = "main"
-optional = true
-python-versions = "*"
 
 [[package]]
 name = "filelock"
@@ -273,43 +257,6 @@ version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
-python-versions = ">=3.5"
-
-[[package]]
-name = "imageio"
-version = "2.20.0"
-description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
-category = "main"
-optional = true
-python-versions = ">=3.7"
-
-[package.dependencies]
-numpy = "*"
-pillow = ">=8.3.2"
-
-[package.extras]
-all-plugins = ["astropy", "av", "imageio-ffmpeg", "opencv-python", "psutil", "tifffile"]
-all-plugins-pypy = ["av", "imageio-ffmpeg", "psutil", "tifffile"]
-build = ["wheel"]
-dev = ["invoke", "pytest", "pytest-cov", "fsspec", "black", "flake8"]
-docs = ["sphinx", "numpydoc", "pydata-sphinx-theme"]
-ffmpeg = ["imageio-ffmpeg", "psutil"]
-fits = ["astropy"]
-full = ["astropy", "av", "black", "flake8", "fsspec", "gdal", "imageio-ffmpeg", "invoke", "itk", "numpydoc", "opencv-python", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx", "tifffile", "wheel"]
-gdal = ["gdal"]
-itk = ["itk"]
-linting = ["black", "flake8"]
-opencv = ["opencv-python"]
-pyav = ["av"]
-test = ["invoke", "pytest", "pytest-cov", "fsspec"]
-tifffile = ["tifffile"]
-
-[[package]]
-name = "imageio-ffmpeg"
-version = "0.4.7"
-description = "FFMPEG wrapper for Python"
-category = "main"
-optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -460,31 +407,6 @@ optional = true
 python-versions = ">=3.7"
 
 [[package]]
-name = "moviepy"
-version = "1.0.3"
-description = "Video editing with Python"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-decorator = ">=4.0.2,<5.0"
-imageio = {version = ">=2.5,<3.0", markers = "python_version >= \"3.4\""}
-imageio_ffmpeg = {version = ">=0.2.0", markers = "python_version >= \"3.4\""}
-numpy = [
-    {version = ">=1.17.3", markers = "python_version != \"2.7\""},
-    {version = "*", markers = "python_version >= \"2.7\""},
-]
-proglog = "<=1.0.0"
-requests = ">=2.8.1,<3.0"
-tqdm = ">=4.11.2,<5.0"
-
-[package.extras]
-doc = ["numpydoc (>=0.6.0,<1.0)", "sphinx_rtd_theme (>=0.1.10b0,<1.0)", "Sphinx (>=1.5.2,<2.0)", "pygame (>=1.9.3,<2.0)"]
-optional = ["youtube-dl", "opencv-python (>=3.0,<4.0)", "scipy (>=0.19.0,<1.5)", "scikit-image (>=0.13.0,<1.0)", "scikit-learn", "matplotlib (>=2.0.0,<3.0)"]
-test = ["coverage (<5.0)", "coveralls (>=1.1,<2.0)", "pytest-cov (>=2.5.1,<3.0)", "pytest (>=3.0.0,<4.0)", "requests (>=2.8.1,<3.0)"]
-
-[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -632,17 +554,6 @@ nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
-
-[[package]]
-name = "proglog"
-version = "0.1.10"
-description = "Log and progress bar manager for console, notebooks, web..."
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-tqdm = "*"
 
 [[package]]
 name = "py"
@@ -1119,12 +1030,12 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [extras]
 docs = ["Sphinx", "sphinx-book-theme", "readthedocs-sphinx-search", "sphinx-autodoc-typehints", "myst-parser", "numpydoc", "docutils"]
-examples = ["cma", "ffmpeg", "moviepy", "matplotlib"]
+examples = ["cma", "matplotlib"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "1571e4eae9449362d7459c6a12769dd63dadc8dd6466310ffc6bfe3f05fc9ac3"
+content-hash = "8c5275738d95bea7cac03652da5b3ae6edc695c24b187256973b709c32527975"
 
 [metadata.files]
 alabaster = [
@@ -1148,10 +1059,8 @@ codecov = []
 colorama = []
 coverage = []
 cycler = []
-decorator = []
 distlib = []
 docutils = []
-ffmpeg = []
 filelock = []
 flake8 = []
 fonttools = []
@@ -1160,8 +1069,6 @@ idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-imageio = []
-imageio-ffmpeg = []
 imagesize = []
 importlib-metadata = []
 iniconfig = [
@@ -1253,7 +1160,6 @@ mccabe = [
 ]
 mdit-py-plugins = []
 mdurl = []
-moviepy = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1342,7 +1248,6 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = []
-proglog = []
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ python = ">=3.7,<3.11"
 numba = "^0.55.0"
 numpy = "^1.19.2"
 scipy = "^1.5.2"
-matplotlib = "^3.3.2"
 tqdm = "^4.61.1"
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.
@@ -55,6 +54,7 @@ docutils = {version = "^0.17.1", optional = true, extras = ["docs"]}
 cma = {version = "^3.2.2", optional = true, extras = ["examples"]}
 ffmpeg = {version = "^1.4", optional = true, extras = ["examples"]}
 moviepy = {version = "^1.0.3", optional = true, extras = ["examples"]}
+matplotlib = {version = "^3.3.2", optional = true, extras = ["examples"]}
 
 [tool.poetry.dev-dependencies]
 black = "21.12b0"
@@ -81,6 +81,7 @@ examples = [
   "cma",
   "ffmpeg",
   "moviepy",
+  "matplotlib",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ myst-parser = {version = "^0.17.2", optional = true, extras = ["docs"]}
 numpydoc = {version = "^1.3.1", optional = true, extras = ["docs"]}
 docutils = {version = "^0.17.1", optional = true, extras = ["docs"]}
 cma = {version = "^3.2.2", optional = true, extras = ["examples"]}
-ffmpeg = {version = "^1.4", optional = true, extras = ["examples"]}
-moviepy = {version = "^1.0.3", optional = true, extras = ["examples"]}
 matplotlib = {version = "^3.3.2", optional = true, extras = ["examples"]}
 
 [tool.poetry.dev-dependencies]
@@ -79,8 +77,6 @@ docs = [
 ]
 examples = [
   "cma",
-  "ffmpeg",
-  "moviepy",
   "matplotlib",
 ]
 


### PR DESCRIPTION
- makes `matplotlib` an optional dependency required for examples
- remove `ffmpeg` install from `pip` (which doesn't work) and adds appropriate `conda install` command