### PR TITLE
Dynamic validation example (#111)

### DIFF
--- a/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
@@ -2,6 +2,56 @@ import numpy as np
 
 
 class AnalyticalDynamicCantilever:
+    """
+    This class computes the analytical solution to a cantilever's dynamic response
+    to an initial velocity profile based on the Euler-Bernoulli beam theory.
+
+    Given the generic dynamic beam equation and boundary conditions imposed on a cantilever,
+    nontrivial solutions exist only when
+
+        cosh(beta * base_length) * cos(beta * base_length) + 1 = 0
+
+    where beta can be used to determine the natural frequencies of the cantilever beam:
+
+        omega = beta^2 * sqrt(E * I / mu)
+
+    The first four roots to beta are given as
+
+        betas = [0.596864*pi, 1.49418*pi, 2.50025*pi, 3.49999*pi] / base_length
+
+    The class solves for the analytical solution at a single natural frequency by computing
+    the non-parametrized mode shapes as well as a mode parameter. The parameter is determined
+    by the initial condition of the rod, namely, the end_velocity input. The free vibration
+    equation can then be applied to determine beam deflection at a given time at any position
+    of the rod:
+
+        w(x, t) = Re[mode_shape * exp(-1j * omega * t)]
+
+    For details, refer to
+    https://en.wikipedia.org/wiki/Euler%E2%80%93Bernoulli_beam_theory#Dynamic_beam_equation
+    or
+    Han et al (1998), Dynamics of Transversely Vibrating Beams
+    Using Four Engineering Theories
+
+        Attributes
+        ----------
+        base_length: float
+            Total length of the rod
+        base_area: float
+            Cross-sectional area of the rod
+        moment_of_inertia: float
+            Second moment of area of the rod's cross-section
+        young's_modulus: float
+            Young's modulus of the rod
+        density: float
+            Density of the rod
+        mode: int
+            Index of the first 'mode' th natural frequency.
+            Up to the first four modes are supported.
+        end_velocity: float
+            Initial oscillatory velocity at the end of the rod
+    """
+
     def __init__(
         self,
         base_length,
@@ -20,18 +70,6 @@ class AnalyticalDynamicCantilever:
         assert mode < 5
         self.mode = mode
 
-        # First four roots to
-        # cosh(beta * base_length) * cos(beta * base_length) + 1 = 0
-        #
-        # Beta values are used to determine natural frequencies of cantilever beams
-        # based on dynamic beam equations
-        # omega = beta^2 * sqrt(E * I / mu)
-        #
-        # For details, refer to
-        # https://en.wikipedia.org/wiki/Euler%E2%80%93Bernoulli_beam_theory#Dynamic_beam_equation
-        # or
-        # Han et al (1998), Dynamics of Transversely Vibrating Beams
-        # Using Four Engineering Theories
         betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length
         self.beta = betas[mode]
         self.omega = (self.beta ** 2) * np.sqrt(

--- a/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
@@ -65,9 +65,11 @@ class AnalyticalDynamicCantilever:
         self.base_length = base_length
         self.end_velocity = end_velocity
 
-        assert isinstance(mode, int)
-        assert mode >= 0
-        assert mode < 5
+        if not (isinstance(mode, int) and mode >= 0 and mode < 5):
+            raise ValueError(
+                "Unsupported mode value, please provide a integer value from 0-4"
+            )
+
         self.mode = mode
 
         betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length

--- a/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/analytical_dynamic_cantilever.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class DynamicCantileverVibration:
+class AnalyticalDynamicCantilever:
     def __init__(
         self,
         base_length,

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -1,0 +1,148 @@
+import numpy as np
+from scipy.fft import fft, fftfreq
+from scipy.signal import find_peaks
+from elastica import *
+from dynamic_cantilever_helper import DynamicCantileverVibration
+
+
+def simulate_dynamic_cantilever_with(
+    density=2000,
+    n_elem=100,
+    final_time=300,
+    mode=0,
+    rendering_fps=30,  # For visualization
+):
+    class DynamicCantileverSimulator(BaseSystemCollection, Constraints, CallBacks):
+        pass
+
+    cantilever_sim = DynamicCantileverSimulator()
+
+    # Add test parameters
+    start = np.zeros((3,))
+    direction = np.array([1.0, 0.0, 0.0])
+    normal = np.array([0.0, 1.0, 0.0])
+    base_length = 1
+    base_radius = 0.02
+    base_area = np.pi * base_radius ** 2
+    youngs_modulus = 1e5
+
+    moi = np.pi / 4 * base_radius ** 4
+
+    dl = base_length / n_elem
+    dt = dl * 0.05
+    step_skips = int(1.0 / (rendering_fps * dt))
+
+    # Add Cosserat rod
+    cantilever = CosseratRod.straight_rod(
+        n_elem,
+        start,
+        direction,
+        normal,
+        base_length,
+        base_radius,
+        density,
+        0.0,
+        youngs_modulus,
+    )
+
+    # Add constraints
+    cantilever_sim.append(cantilever)
+    cantilever_sim.constrain(cantilever).using(
+        OneEndFixedBC, constrained_position_idx=(0,), constrained_director_idx=(0,)
+    )
+
+    end_velocity = 0.005
+    vibration = DynamicCantileverVibration(
+        base_length,
+        base_area,
+        moi,
+        youngs_modulus,
+        density,
+        mode=mode,
+        end_velocity_z=end_velocity,
+    )
+
+    input_velocity = vibration.get_initial_velocity_profile(
+        cantilever.position_collection[0, :]
+    )
+    cantilever.velocity_collection[2, :] = input_velocity
+
+    # Add call backs
+    class CantileverCallBack(CallBackBaseClass):
+        def __init__(self, step_skip: int, callback_params: dict):
+            CallBackBaseClass.__init__(self)
+            self.every = step_skip
+            self.callback_params = callback_params
+
+        def make_callback(self, system, time, current_step: int):
+
+            if current_step % self.every == 0:
+
+                self.callback_params["time"].append(time)
+                self.callback_params["position"].append(
+                    system.position_collection.copy()
+                )
+                self.callback_params["z_position"].append(
+                    system.position_collection[2, -1].copy()
+                )
+                return
+
+    recorded_history = defaultdict(list)
+    cantilever_sim.collect_diagnostics(cantilever).using(
+        CantileverCallBack, step_skip=step_skips, callback_params=recorded_history
+    )
+    cantilever_sim.finalize()
+
+    total_steps = int(final_time / dt)
+    print(f"Total steps: {total_steps}")
+
+    timestepper = PositionVerlet()
+
+    integrate(
+        timestepper,
+        cantilever_sim,
+        final_time,
+        total_steps,
+    )
+
+    # FFT
+    amps = np.abs(fft(recorded_history["z_position"]))
+    f_length = len(amps)
+    amps = amps * 2 / f_length
+    omegas = fftfreq(f_length, dt * step_skips) * 2 * np.pi  # [rad/s]
+
+    try:
+        peaks, _ = find_peaks(amps)
+        peak = peaks[np.argmax(amps[peaks])]
+
+        simulated_frequency = omegas[peak]
+        theoretical_frequency = vibration.get_omega()
+
+        simulated_amplitude = max(recorded_history["z_position"])
+        theoretical_amplitude = vibration.get_amplitude()
+
+        print(
+            f"Theoretical frequency: {theoretical_frequency} rad/s \n"
+            f"Simulated frequency: {simulated_frequency} rad/s \n"
+            f"Theoretical amplitude: {theoretical_amplitude} m \n"
+            f"Simulated amplitude: {simulated_amplitude} m"
+        )
+
+        # error_frequency = abs(simulated_frequency - resonant_frequency) / resonant_frequency
+        # error_amplitude = abs(simulated_amplitude - resonant_amplitude) / resonant_amplitude
+
+        return {
+            "rod": cantilever,
+            "recorded_history": recorded_history,
+            "fft_frequencies": omegas,
+            "fft_amplitudes": amps,
+            "vibration": vibration,
+            "peak": peak,
+            "simulated_frequency": simulated_frequency,
+            "theoretical_frequency": theoretical_frequency,
+            "simulated_amplitude": simulated_amplitude,
+            "theoretical_amplitude": theoretical_amplitude,
+        }
+
+    except IndexError:
+        print("No peaks detected: change input parameters.")

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.fft import fft, fftfreq
 from scipy.signal import find_peaks
 from elastica import *
-from dynamic_cantilever_helper import DynamicCantileverVibration
+from analytical_dynamic_cantilever import AnalyticalDynamicCantilever
 
 
 def simulate_dynamic_cantilever_with(
@@ -52,7 +52,7 @@ def simulate_dynamic_cantilever_with(
     )
 
     end_velocity = 0.005
-    vibration = DynamicCantileverVibration(
+    analytical_cantilever_soln = AnalyticalDynamicCantilever(
         base_length,
         base_area,
         moment_of_inertia,
@@ -62,7 +62,7 @@ def simulate_dynamic_cantilever_with(
         end_velocity=end_velocity,
     )
 
-    initial_velocity = vibration.get_initial_velocity_profile(
+    initial_velocity = analytical_cantilever_soln.get_initial_velocity_profile(
         cantilever_rod.position_collection[0, :]
     )
     cantilever_rod.velocity_collection[2, :] = initial_velocity
@@ -116,10 +116,10 @@ def simulate_dynamic_cantilever_with(
         peak = peaks[np.argmax(amplitudes[peaks])]
 
         simulated_frequency = omegas[peak]
-        theoretical_frequency = vibration.get_omega()
+        theoretical_frequency = analytical_cantilever_soln.get_omega()
 
         simulated_amplitude = max(recorded_history["deflection"])
-        theoretical_amplitude = vibration.get_amplitude()
+        theoretical_amplitude = analytical_cantilever_soln.get_amplitude()
 
         print(
             f"Theoretical frequency: {theoretical_frequency} rad/s \n"
@@ -133,7 +133,7 @@ def simulate_dynamic_cantilever_with(
             "recorded_history": recorded_history,
             "fft_frequencies": omegas,
             "fft_amplitudes": amplitudes,
-            "vibration": vibration,
+            "analytical_cantilever_soln": analytical_cantilever_soln,
             "peak": peak,
             "simulated_frequency": simulated_frequency,
             "theoretical_frequency": theoretical_frequency,

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -6,12 +6,37 @@ from analytical_dynamic_cantilever import AnalyticalDynamicCantilever
 
 
 def simulate_dynamic_cantilever_with(
-    density=2000,
+    density=2000.0,
     n_elem=100,
-    final_time=300,
+    final_time=300.0,
     mode=0,
-    rendering_fps=30,  # For visualization
+    rendering_fps=30.0,  # For visualization
 ):
+    """
+    This function completes a dynamic cantilever simulation with the given parameters.
+
+    Parameters
+    ----------
+    density: float
+        Density of the rod
+    n_elem: int
+        The number of elements of the rod
+    final_time: float
+        Total simulation time. The timestep is determined by final_time / n_steps.
+    mode: int
+        Index of the first 'mode' th natural frequency.
+        Up to the first four modes are supported.
+    rendering_fps: float
+        Frames per second for video plotting.
+        The call back step-skip is also determined by rendering_fps.
+
+    Returns
+    -------
+    dict of {str : int}
+        A collection of parameters for post-processing.
+
+    """
+
     class DynamicCantileverSimulator(BaseSystemCollection, Constraints, CallBacks):
         pass
 

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -26,7 +26,7 @@ def simulate_dynamic_cantilever_with(
     base_area = np.pi * base_radius ** 2
     youngs_modulus = 1e5
 
-    I = np.pi / 4 * base_radius ** 4
+    moment_of_inertia = np.pi / 4 * base_radius ** 4
 
     dl = base_length / n_elem
     dt = dl * 0.05
@@ -55,7 +55,7 @@ def simulate_dynamic_cantilever_with(
     vibration = DynamicCantileverVibration(
         base_length,
         base_area,
-        I,
+        moment_of_inertia,
         youngs_modulus,
         density,
         mode=mode,

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -128,9 +128,6 @@ def simulate_dynamic_cantilever_with(
             f"Simulated amplitude: {simulated_amplitude} m"
         )
 
-        # error_frequency = abs(simulated_frequency - resonant_frequency) / resonant_frequency
-        # error_amplitude = abs(simulated_amplitude - resonant_amplitude) / resonant_amplitude
-
         return {
             "rod": cantilever,
             "recorded_history": recorded_history,

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -33,7 +33,7 @@ def simulate_dynamic_cantilever_with(
     step_skips = int(1.0 / (rendering_fps * dt))
 
     # Add Cosserat rod
-    cantilever = CosseratRod.straight_rod(
+    cantilever_rod = CosseratRod.straight_rod(
         n_elem,
         start,
         direction,
@@ -46,8 +46,8 @@ def simulate_dynamic_cantilever_with(
     )
 
     # Add constraints
-    cantilever_sim.append(cantilever)
-    cantilever_sim.constrain(cantilever).using(
+    cantilever_sim.append(cantilever_rod)
+    cantilever_sim.constrain(cantilever_rod).using(
         OneEndFixedBC, constrained_position_idx=(0,), constrained_director_idx=(0,)
     )
 
@@ -63,9 +63,9 @@ def simulate_dynamic_cantilever_with(
     )
 
     initial_velocity = vibration.get_initial_velocity_profile(
-        cantilever.position_collection[0, :]
+        cantilever_rod.position_collection[0, :]
     )
-    cantilever.velocity_collection[2, :] = initial_velocity
+    cantilever_rod.velocity_collection[2, :] = initial_velocity
 
     # Add call backs
     class CantileverCallBack(CallBackBaseClass):
@@ -88,7 +88,7 @@ def simulate_dynamic_cantilever_with(
                 return
 
     recorded_history = defaultdict(list)
-    cantilever_sim.collect_diagnostics(cantilever).using(
+    cantilever_sim.collect_diagnostics(cantilever_rod).using(
         CantileverCallBack, step_skip=step_skips, callback_params=recorded_history
     )
     cantilever_sim.finalize()
@@ -129,7 +129,7 @@ def simulate_dynamic_cantilever_with(
         )
 
         return {
-            "rod": cantilever,
+            "rod": cantilever_rod,
             "recorded_history": recorded_history,
             "fft_frequencies": omegas,
             "fft_amplitudes": amplitudes,

--- a/examples/DynamicCantileverCase/dynamic_cantilever.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever.py
@@ -141,5 +141,5 @@ def simulate_dynamic_cantilever_with(
             "theoretical_amplitude": theoretical_amplitude,
         }
 
-    except IndexError:
+    except RuntimeError:
         print("No peaks detected: change input parameters.")

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -6,7 +6,7 @@ class DynamicCantileverVibration:
         self,
         base_length,
         base_area,
-        I,
+        moment_of_inertia,
         youngs_modulus,
         density,
         mode,
@@ -23,7 +23,9 @@ class DynamicCantileverVibration:
         betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length
         self.beta = betas[mode]
         self.omega = (self.beta ** 2) * np.sqrt(
-            youngs_modulus * I / (density * base_area * base_length ** 4)
+            youngs_modulus
+            * moment_of_inertia
+            / (density * base_area * base_length ** 4)
         )
 
         nonparametrized_mode_at_end = self._compute_nonparametrized_mode(

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -33,22 +33,6 @@ class DynamicCantileverVibration:
         )
         self.param = end_velocity_z / (-1j * self.omega * np_mode_l)
 
-        # if mode > 1:
-        #     step = 1.0 / (mode - 1)
-        #     test_x = np.arange(0.0, 1.0 + step, step=step)[1:] * base_length
-        #     param_mat = np.zeros([mode, mode], dtype="complex128")
-        #     target_mat = np.zeros([mode, 1], dtype="complex128")
-        #
-        #     for i, x in np.ndenumerate(test_x):
-        #         param_mat[i, :] = self._compute_nonparametrized_mode(x, base_length, self.betas)
-        #         target_mat[i] = 0.0
-        #
-        #     param_mat[-1, :] = -1j * self.omegas * np_modes_l
-        #     target_mat[-1] = end_velocity_z
-        #
-        #     soln_mat = la.solve(param_mat, target_mat)
-        #     self.params = soln_mat.ravel()
-
     def get_initial_position_profile(self, x_coords):
         positions = []
 

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -1,0 +1,112 @@
+import numpy as np
+
+
+class DynamicCantileverVibration:
+    def __init__(
+        self,
+        base_length,
+        base_area,
+        moment_of_inertia,
+        youngs_modulus,
+        density,
+        mode,
+        end_velocity_z=0.0,
+    ):
+        self.base_length = base_length
+        self.end_velocity_z = end_velocity_z
+
+        assert isinstance(mode, int)
+        assert mode >= 0
+        assert mode < 5
+        self.mode = mode
+
+        betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length
+        self.beta = betas[mode]
+        self.omega = (self.beta ** 2) * np.sqrt(
+            youngs_modulus
+            * moment_of_inertia
+            / (density * base_area * base_length ** 4)
+        )
+
+        np_mode_l = self._compute_nonparametrized_mode(
+            base_length, base_length, self.beta
+        )
+        self.param = end_velocity_z / (-1j * self.omega * np_mode_l)
+
+        # if mode > 1:
+        #     step = 1.0 / (mode - 1)
+        #     test_x = np.arange(0.0, 1.0 + step, step=step)[1:] * base_length
+        #     param_mat = np.zeros([mode, mode], dtype="complex128")
+        #     target_mat = np.zeros([mode, 1], dtype="complex128")
+        #
+        #     for i, x in np.ndenumerate(test_x):
+        #         param_mat[i, :] = self._compute_nonparametrized_mode(x, base_length, self.betas)
+        #         target_mat[i] = 0.0
+        #
+        #     param_mat[-1, :] = -1j * self.omegas * np_modes_l
+        #     target_mat[-1] = end_velocity_z
+        #
+        #     soln_mat = la.solve(param_mat, target_mat)
+        #     self.params = soln_mat.ravel()
+
+    def get_initial_position_profile(self, x_coords):
+        positions = []
+
+        for x in x_coords:
+            positions.append(
+                np.real(
+                    self.param
+                    * self._compute_nonparametrized_mode(
+                        self.base_length * x, self.base_length, self.beta
+                    )
+                )
+            )
+        return np.array(positions)
+
+    def get_initial_velocity_profile(self, x_coords):
+        velocities = []
+
+        for x in x_coords:
+            velocities.append(
+                np.real(
+                    (-1j * self.omega * self.param)
+                    * self._compute_nonparametrized_mode(
+                        self.base_length * x, self.base_length, self.beta
+                    )
+                )
+            )
+        return np.array(velocities)
+
+    def get_positions(self, x_coord, time_array):
+        positions = (
+            self.param
+            * self._compute_nonparametrized_mode(
+                self.base_length * x_coord, self.base_length, self.beta
+            )
+            * np.exp(-1j * self.omega * time_array)
+        )
+        return np.real(positions)
+
+    def get_velocities(self, x_coord, time_array):
+        velocities = (
+            (-1j * self.omega * self.param)
+            * self._compute_nonparametrized_mode(
+                self.base_length * x_coord, self.base_length, self.beta
+            )
+            * np.exp(-1j * self.omega * time_array)
+        )
+        return np.real(velocities)
+
+    def get_omega(self):
+        return self.omega
+
+    def get_amplitude(self):
+        return self.end_velocity_z / self.omega
+
+    @staticmethod
+    def _compute_nonparametrized_mode(x, base_length, betas):
+        a = np.cosh(betas * x) - np.cos(betas * x)
+        b = np.cos(betas * base_length) + np.cosh(betas * base_length)
+        c = np.sin(betas * base_length) + np.sinh(betas * base_length)
+        d = np.sin(betas * x) - np.sinh(betas * x)
+        return a + b / c * d

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -20,6 +20,18 @@ class DynamicCantileverVibration:
         assert mode < 5
         self.mode = mode
 
+        # First four roots to
+        # cosh(beta * base_length) * cos(beta * base_length) + 1 = 0
+        #
+        # Beta values are used to determine natural frequencies of cantilever beams
+        # based on dynamic beam equations
+        # omega = beta^2 * sqrt(E * I / mu)
+        #
+        # For details, refer to
+        # https://en.wikipedia.org/wiki/Euler%E2%80%93Bernoulli_beam_theory#Dynamic_beam_equation
+        # or
+        # Han et al (1998), Dynamics of Transversely Vibrating Beams
+        # Using Four Engineering Theories
         betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length
         self.beta = betas[mode]
         self.omega = (self.beta ** 2) * np.sqrt(

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -35,20 +35,6 @@ class DynamicCantileverVibration:
             -1j * self.omega * nonparametrized_mode_at_end
         )
 
-    def get_initial_position_profile(self, x_coords):
-        positions = []
-
-        for x in x_coords:
-            positions.append(
-                np.real(
-                    self.mode_param
-                    * self._compute_nonparametrized_mode(
-                        self.base_length * x, self.base_length, self.beta
-                    )
-                )
-            )
-        return np.array(positions)
-
     def get_initial_velocity_profile(self, positions):
         initial_velocities = []
 

--- a/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_helper.py
@@ -6,14 +6,14 @@ class DynamicCantileverVibration:
         self,
         base_length,
         base_area,
-        moment_of_inertia,
+        I,
         youngs_modulus,
         density,
         mode,
-        end_velocity_z=0.0,
+        end_velocity=0.0,
     ):
         self.base_length = base_length
-        self.end_velocity_z = end_velocity_z
+        self.end_velocity = end_velocity
 
         assert isinstance(mode, int)
         assert mode >= 0
@@ -23,15 +23,15 @@ class DynamicCantileverVibration:
         betas = np.array([0.596864, 1.49418, 2.50025, 3.49999]) * np.pi / base_length
         self.beta = betas[mode]
         self.omega = (self.beta ** 2) * np.sqrt(
-            youngs_modulus
-            * moment_of_inertia
-            / (density * base_area * base_length ** 4)
+            youngs_modulus * I / (density * base_area * base_length ** 4)
         )
 
-        np_mode_l = self._compute_nonparametrized_mode(
+        nonparametrized_mode_at_end = self._compute_nonparametrized_mode(
             base_length, base_length, self.beta
         )
-        self.param = end_velocity_z / (-1j * self.omega * np_mode_l)
+        self.mode_param = end_velocity / (
+            -1j * self.omega * nonparametrized_mode_at_end
+        )
 
     def get_initial_position_profile(self, x_coords):
         positions = []
@@ -39,7 +39,7 @@ class DynamicCantileverVibration:
         for x in x_coords:
             positions.append(
                 np.real(
-                    self.param
+                    self.mode_param
                     * self._compute_nonparametrized_mode(
                         self.base_length * x, self.base_length, self.beta
                     )
@@ -47,50 +47,50 @@ class DynamicCantileverVibration:
             )
         return np.array(positions)
 
-    def get_initial_velocity_profile(self, x_coords):
-        velocities = []
+    def get_initial_velocity_profile(self, positions):
+        initial_velocities = []
 
-        for x in x_coords:
-            velocities.append(
+        for x in positions:
+            initial_velocities.append(
                 np.real(
-                    (-1j * self.omega * self.param)
+                    (-1j * self.omega * self.mode_param)
                     * self._compute_nonparametrized_mode(
                         self.base_length * x, self.base_length, self.beta
                     )
                 )
             )
-        return np.array(velocities)
+        return np.array(initial_velocities)
 
-    def get_positions(self, x_coord, time_array):
-        positions = (
-            self.param
+    def get_time_dependent_positions(self, position, time_array):
+        time_dependent_positions = (
+            self.mode_param
             * self._compute_nonparametrized_mode(
-                self.base_length * x_coord, self.base_length, self.beta
+                self.base_length * position, self.base_length, self.beta
             )
             * np.exp(-1j * self.omega * time_array)
         )
-        return np.real(positions)
+        return np.real(time_dependent_positions)
 
-    def get_velocities(self, x_coord, time_array):
-        velocities = (
-            (-1j * self.omega * self.param)
+    def get_time_dependent_velocities(self, position, time_array):
+        time_dependent_velocities = (
+            (-1j * self.omega * self.mode_param)
             * self._compute_nonparametrized_mode(
-                self.base_length * x_coord, self.base_length, self.beta
+                self.base_length * position, self.base_length, self.beta
             )
             * np.exp(-1j * self.omega * time_array)
         )
-        return np.real(velocities)
+        return np.real(time_dependent_velocities)
 
     def get_omega(self):
         return self.omega
 
     def get_amplitude(self):
-        return self.end_velocity_z / self.omega
+        return self.end_velocity / self.omega
 
     @staticmethod
-    def _compute_nonparametrized_mode(x, base_length, betas):
-        a = np.cosh(betas * x) - np.cos(betas * x)
-        b = np.cos(betas * base_length) + np.cosh(betas * base_length)
-        c = np.sin(betas * base_length) + np.sinh(betas * base_length)
-        d = np.sin(betas * x) - np.sinh(betas * x)
+    def _compute_nonparametrized_mode(x, base_length, beta):
+        a = np.cosh(beta * x) - np.cos(beta * x)
+        b = np.cos(beta * base_length) + np.cosh(beta * base_length)
+        c = np.sin(beta * base_length) + np.sinh(beta * base_length)
+        d = np.sin(beta * x) - np.sinh(beta * x)
         return a + b / c * d

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
         theory_amplitude.append(result["theoretical_amplitude"])
         sim_amplitude.append(result["simulated_amplitude"])
 
+    # Plot frequencies and amplitudes vs densities
     fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
 
     ax_freq = fig.add_subplot(121)

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -1,3 +1,6 @@
+__doc__ = """ Validating phase space of dynamic cantilever beam vibration with  respect to varying densities.
+The theoretical dynamic response is obtained via Euler-Bernoulli beam theory."""
+
 from dynamic_cantilever_post_processing import plot_phase_space_with
 from dynamic_cantilever import simulate_dynamic_cantilever_with
 

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -14,15 +14,15 @@ if __name__ == "__main__":
     with mp.Pool(mp.cpu_count()) as pool:
         results = pool.map(simulate_dynamic_cantilever_with, densities)
 
-    thry_frequency = []
+    theory_frequency = []
     sim_frequency = []
-    thry_amplitude = []
+    theory_amplitude = []
     sim_amplitude = []
 
     for result in results:
-        thry_frequency.append(result["theoretical_frequency"])
+        theory_frequency.append(result["theoretical_frequency"])
         sim_frequency.append(result["simulated_frequency"])
-        thry_amplitude.append(result["theoretical_amplitude"])
+        theory_amplitude.append(result["theoretical_amplitude"])
         sim_amplitude.append(result["simulated_amplitude"])
 
     fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     ax_freq.grid(visible=True, which="both", color="k", linestyle="-")
     ax_freq.plot(
         densities,
-        thry_frequency,
+        theory_frequency,
         color="k",
         marker="o",
         ms=8,
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     ax_amp.grid(visible=True, which="both", color="k", linestyle="-")
     ax_amp.plot(
         densities,
-        thry_amplitude,
+        theory_amplitude,
         color="k",
         marker="o",
         ms=8,

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -1,4 +1,4 @@
-__doc__ = """ Validating phase space of dynamic cantilever beam vibration with  respect to varying densities.
+__doc__ = """ Validating phase space of dynamic cantilever beam analytical_cantilever_soln with  respect to varying densities.
 The theoretical dynamic response is obtained via Euler-Bernoulli beam theory."""
 
 from dynamic_cantilever_post_processing import plot_phase_space_with

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -1,4 +1,4 @@
-import matplotlib.pyplot as plt
+from dynamic_cantilever_post_processing import plot_phase_space_with
 from dynamic_cantilever import simulate_dynamic_cantilever_with
 
 if __name__ == "__main__":
@@ -26,60 +26,12 @@ if __name__ == "__main__":
         sim_amplitude.append(result["simulated_amplitude"])
 
     # Plot frequencies and amplitudes vs densities
-    fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
-
-    ax_freq = fig.add_subplot(121)
-    ax_freq.grid(visible=True, which="both", color="k", linestyle="-")
-    ax_freq.plot(
+    plot_phase_space_with(
         densities,
         theory_frequency,
-        color="k",
-        marker="o",
-        ms=8,
-        lw=2,
-        label="theoretical_frequency",
-    )
-    ax_freq.plot(
-        densities,
         sim_frequency,
-        color="r",
-        marker="o",
-        ms=8,
-        lw=2,
-        label="simulated_frequency",
-    )
-    ax_freq.set_ylim([0, 0.6])
-    ax_freq.set_xlabel(r"Density [$kg/m^3$]")
-    ax_freq.set_ylabel(r"Frequency [$rad/s$]")
-    ax_freq.legend()
-
-    ax_amp = fig.add_subplot(122)
-    ax_amp.grid(visible=True, which="both", color="k", linestyle="-")
-    ax_amp.plot(
-        densities,
         theory_amplitude,
-        color="k",
-        marker="o",
-        ms=8,
-        lw=2,
-        label="theoretical_amplitude",
-    )
-    ax_amp.plot(
-        densities,
         sim_amplitude,
-        color="r",
-        marker="o",
-        ms=8,
-        lw=2,
-        label="simulated_amplitude",
+        PLOT_FIGURE=PLOT_FIGURE,
+        SAVE_FIGURE=SAVE_FIGURE,
     )
-    ax_amp.set_ylim([0, 0.05])
-    ax_amp.set_xlabel(r"Density [$kg/m^3$]")
-    ax_amp.set_ylabel(r"Amplitude [$m$]")
-    ax_amp.legend()
-
-    if PLOT_FIGURE:
-        plt.show()
-
-    if SAVE_FIGURE:
-        fig.savefig("Dynamic_cantilever_phase_plot.png")

--- a/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_phase_space.py
@@ -1,0 +1,84 @@
+import matplotlib.pyplot as plt
+from dynamic_cantilever import simulate_dynamic_cantilever_with
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+
+    PLOT_FIGURE = True
+    SAVE_FIGURE = False
+
+    # density = 500, 1000, 2000, 3000, 4000, 5000 kg/m3
+    densities = [500]
+    densities.extend(range(1000, 6000, 1000))
+
+    with mp.Pool(mp.cpu_count()) as pool:
+        results = pool.map(simulate_dynamic_cantilever_with, densities)
+
+    thry_frequency = []
+    sim_frequency = []
+    thry_amplitude = []
+    sim_amplitude = []
+
+    for result in results:
+        thry_frequency.append(result["theoretical_frequency"])
+        sim_frequency.append(result["simulated_frequency"])
+        thry_amplitude.append(result["theoretical_amplitude"])
+        sim_amplitude.append(result["simulated_amplitude"])
+
+    fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
+
+    ax_freq = fig.add_subplot(121)
+    ax_freq.grid(visible=True, which="both", color="k", linestyle="-")
+    ax_freq.plot(
+        densities,
+        thry_frequency,
+        color="k",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="theoretical_frequency",
+    )
+    ax_freq.plot(
+        densities,
+        sim_frequency,
+        color="r",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="simulated_frequency",
+    )
+    ax_freq.set_ylim([0, 0.6])
+    ax_freq.set_xlabel(r"Density [$kg/m^3$]")
+    ax_freq.set_ylabel(r"Frequency [$rad/s$]")
+    ax_freq.legend()
+
+    ax_amp = fig.add_subplot(122)
+    ax_amp.grid(visible=True, which="both", color="k", linestyle="-")
+    ax_amp.plot(
+        densities,
+        thry_amplitude,
+        color="k",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="theoretical_amplitude",
+    )
+    ax_amp.plot(
+        densities,
+        sim_amplitude,
+        color="r",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="simulated_amplitude",
+    )
+    ax_amp.set_ylim([0, 0.05])
+    ax_amp.set_xlabel(r"Density [$kg/m^3$]")
+    ax_amp.set_ylabel(r"Amplitude [$m$]")
+    ax_amp.legend()
+
+    if PLOT_FIGURE:
+        plt.show()
+
+    if SAVE_FIGURE:
+        fig.savefig("Dynamic_cantilever_phase_plot.png")

--- a/examples/DynamicCantileverCase/dynamic_cantilever_post_processing.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_post_processing.py
@@ -1,0 +1,151 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# Plotting frequency and amplitudes against densities
+def plot_phase_space_with(
+    densities,
+    theory_frequency,
+    sim_frequency,
+    theory_amplitude,
+    sim_amplitude,
+    PLOT_FIGURE=True,
+    SAVE_FIGURE=False,
+):
+
+    fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
+
+    ax_freq = fig.add_subplot(121)
+    ax_freq.grid(visible=True, which="both", color="k", linestyle="-")
+    ax_freq.plot(
+        densities,
+        theory_frequency,
+        color="k",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="theoretical_frequency",
+    )
+    ax_freq.plot(
+        densities,
+        sim_frequency,
+        color="r",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="simulated_frequency",
+    )
+    ax_freq.set_ylim([0, 0.6])
+    ax_freq.set_xlabel(r"Density [$kg/m^3$]")
+    ax_freq.set_ylabel(r"Frequency [$rad/s$]")
+    ax_freq.legend()
+
+    ax_amp = fig.add_subplot(122)
+    ax_amp.grid(visible=True, which="both", color="k", linestyle="-")
+    ax_amp.plot(
+        densities,
+        theory_amplitude,
+        color="k",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="theoretical_amplitude",
+    )
+    ax_amp.plot(
+        densities,
+        sim_amplitude,
+        color="r",
+        marker="o",
+        ms=8,
+        lw=2,
+        label="simulated_amplitude",
+    )
+    ax_amp.set_ylim([0, 0.05])
+    ax_amp.set_xlabel(r"Density [$kg/m^3$]")
+    ax_amp.set_ylabel(r"Amplitude [$m$]")
+    ax_amp.legend()
+
+    if PLOT_FIGURE:
+        plt.show()
+
+    if SAVE_FIGURE:
+        fig.savefig("Dynamic_cantilever_phase_plot.png")
+
+
+def plot_end_position_with(
+    recorded_history,
+    vibration,
+    omegas,
+    amplitudes,
+    peak,
+    PLOT_FIGURE,
+    SAVE_FIGURE,
+):
+    fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
+    ax = fig.add_subplot(121)
+    ax.plot(
+        recorded_history["time"],
+        recorded_history["deflection"],
+        lw=2.0,
+        label="Cosserat rod model",
+    )
+    ax.set_xlabel("Time [s]", fontsize=16)
+    ax.set_ylabel("Displacement [m]", fontsize=16)
+    ax.grid(visible=True, which="both", color="k", linestyle="--")
+
+    time = np.array(recorded_history["time"])
+    positions = vibration.get_time_dependent_positions(1, time)
+
+    ax.plot(time, positions, lw=2.0, label="Euler-Bernoulli beam theory")
+    ax.legend()
+
+    # FFT plot
+    fft_ax = fig.add_subplot(122)
+    fft_ax.plot(omegas, amplitudes, lw=2, color="k")
+    fft_ax.set_xlim([0, vibration.get_omega() * 2])
+
+    fft_ax.set_xlabel("Frequency [rad/s]", fontsize=16)
+    fft_ax.set_ylabel("Amplitude [m]", fontsize=16)
+
+    fft_ax.plot(omegas[peak], amplitudes[peak], "*", color="red", ms=8)
+
+    if PLOT_FIGURE:
+        plt.show()
+
+    if SAVE_FIGURE:
+        fig.savefig("Dynamic_cantilever_visualization.png")
+
+
+def plot_dynamic_cantilever_video_with(
+    mode,
+    recorded_history,
+    rendering_fps,
+):
+    print("Plotting video ...")
+    video_name = f"Dynamic_cantilever_mode_{mode + 1}.mp4"
+
+    import matplotlib.animation as manimation
+    from tqdm import tqdm
+
+    positions_over_time = np.array(recorded_history["position"])
+
+    FFMpegWriter = manimation.writers["ffmpeg"]
+    metadata = dict(title="Movie Test", artist="Matplotlib", comment="Movie support!")
+    writer = FFMpegWriter(fps=rendering_fps, metadata=metadata)
+    mvfig = plt.figure(figsize=(10, 8), frameon=True, dpi=150)
+    ax = mvfig.add_subplot(111)
+    ax.set_xlim([0, 1.25])
+    ax.set_ylim([-0.02, 0.02])
+    ax.set_xlabel("x [m]", fontsize=16)
+    ax.set_ylabel("z [m]", fontsize=16)
+    rod_lines_2d = ax.plot(
+        positions_over_time[0][0], positions_over_time[0][2], lw=8, color="k"
+    )[0]
+
+    with writer.saving(mvfig, video_name, dpi=150):
+        for t in tqdm(range(1, len(recorded_history["time"]))):
+            rod_lines_2d.set_xdata(positions_over_time[t][0])
+            rod_lines_2d.set_ydata(positions_over_time[t][2])
+            writer.grab_frame()
+
+    plt.close(plt.gcf())

--- a/examples/DynamicCantileverCase/dynamic_cantilever_post_processing.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_post_processing.py
@@ -74,7 +74,7 @@ def plot_phase_space_with(
 
 def plot_end_position_with(
     recorded_history,
-    vibration,
+    analytical_cantilever_soln,
     omegas,
     amplitudes,
     peak,
@@ -94,7 +94,7 @@ def plot_end_position_with(
     ax.grid(visible=True, which="both", color="k", linestyle="--")
 
     time = np.array(recorded_history["time"])
-    positions = vibration.get_time_dependent_positions(1, time)
+    positions = analytical_cantilever_soln.get_time_dependent_positions(1, time)
 
     ax.plot(time, positions, lw=2.0, label="Euler-Bernoulli beam theory")
     ax.legend()
@@ -102,7 +102,7 @@ def plot_end_position_with(
     # FFT plot
     fft_ax = fig.add_subplot(122)
     fft_ax.plot(omegas, amplitudes, lw=2, color="k")
-    fft_ax.set_xlim([0, vibration.get_omega() * 2])
+    fft_ax.set_xlim([0, analytical_cantilever_soln.get_omega() * 2])
 
     fft_ax.set_xlabel("Frequency [rad/s]", fontsize=16)
     fft_ax.set_ylabel("Amplitude [m]", fontsize=16)

--- a/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
@@ -19,7 +19,7 @@ PLOT_VIDEO = True
 n_elem = 200
 final_time = 100
 rendering_fps = 30
-mode = 2
+mode = 0
 
 sim_result = simulate_dynamic_cantilever_with(
     density=500,
@@ -41,7 +41,7 @@ fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
 ax = fig.add_subplot(121)
 ax.plot(
     recorded_history["time"],
-    recorded_history["z_position"],
+    recorded_history["deflection"],
     lw=2.0,
     label="Cosserat rod model",
 )
@@ -51,7 +51,7 @@ ax.grid(visible=True, which="both", color="k", linestyle="--")
 
 times = np.array(recorded_history["time"])
 
-positions = vibration.get_positions(1, times)
+positions = vibration.get_time_dependent_positions(1, times)
 ax.plot(times, positions, lw=2.0, label="Euler-Bernoulli beam theory")
 ax.legend()
 

--- a/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
@@ -1,7 +1,9 @@
-import numpy as np
-from matplotlib import pyplot as plt
 from elastica import *
 from dynamic_cantilever import simulate_dynamic_cantilever_with
+from dynamic_cantilever_post_processing import (
+    plot_end_position_with,
+    plot_dynamic_cantilever_video_with,
+)
 
 
 class DynamicCantileverSimulator(BaseSystemCollection, Constraints, CallBacks):
@@ -12,7 +14,7 @@ cantilever_sim = DynamicCantileverSimulator()
 
 # Options
 PLOT_FIGURE = True
-SAVE_FIGURE = False
+SAVE_FIGURE = True
 PLOT_VIDEO = True
 
 # Add test parameters
@@ -32,71 +34,23 @@ sim_result = simulate_dynamic_cantilever_with(
 cantilever = sim_result["rod"]
 recorded_history = sim_result["recorded_history"]
 omegas = sim_result["fft_frequencies"]
-amps = sim_result["fft_amplitudes"]
+amplitudes = sim_result["fft_amplitudes"]
 vibration = sim_result["vibration"]
 peak = sim_result["peak"]
 
-# End position time-dependent plot
-fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
-ax = fig.add_subplot(121)
-ax.plot(
-    recorded_history["time"],
-    recorded_history["deflection"],
-    lw=2.0,
-    label="Cosserat rod model",
-)
-ax.set_xlabel("Time [s]", fontsize=16)
-ax.set_ylabel("Displacement [m]", fontsize=16)
-ax.grid(visible=True, which="both", color="k", linestyle="--")
+# Plotting end-point position over time
+# and frequency-domain equivalent
+if PLOT_FIGURE or SAVE_FIGURE:
+    plot_end_position_with(
+        recorded_history,
+        vibration,
+        omegas,
+        amplitudes,
+        peak,
+        PLOT_FIGURE,
+        SAVE_FIGURE,
+    )
 
-times = np.array(recorded_history["time"])
-
-positions = vibration.get_time_dependent_positions(1, times)
-ax.plot(times, positions, lw=2.0, label="Euler-Bernoulli beam theory")
-ax.legend()
-
-# FFT plot
-fft_ax = fig.add_subplot(122)
-fft_ax.plot(omegas, amps, lw=2, color="k")
-fft_ax.set_xlim([0, vibration.get_omega() * 2])
-
-fft_ax.set_xlabel("Frequency [rad/s]", fontsize=16)
-fft_ax.set_ylabel("Amplitude [m]", fontsize=16)
-
-fft_ax.plot(omegas[peak], amps[peak], "*", color="red", ms=8)
-
-if PLOT_FIGURE:
-    plt.show()
-
-if SAVE_FIGURE:
-    fig.savefig("Dynamic_cantilever_visualization.png")
-
+# Plotting video
 if PLOT_VIDEO:
-    print("Plotting video ...")
-    video_name = f"Dynamic_cantilever_mode_{mode+1}.mp4"
-
-    import matplotlib.animation as manimation
-    from tqdm import tqdm
-
-    positions_over_time = np.array(recorded_history["position"])
-
-    FFMpegWriter = manimation.writers["ffmpeg"]
-    metadata = dict(title="Movie Test", artist="Matplotlib", comment="Movie support!")
-    writer = FFMpegWriter(fps=rendering_fps, metadata=metadata)
-    mvfig = plt.figure(figsize=(10, 8), frameon=True, dpi=150)
-    ax = mvfig.add_subplot(111)
-    ax.set_xlim([0, 1.25])
-    ax.set_ylim([-0.02, 0.02])
-    ax.set_xlabel("x [m]", fontsize=16)
-    ax.set_ylabel("z [m]", fontsize=16)
-    rod_lines_2d = ax.plot(
-        positions_over_time[0][0], positions_over_time[0][2], lw=8, color="k"
-    )[0]
-
-    with writer.saving(mvfig, video_name, dpi=150):
-        for t in tqdm(range(1, len(recorded_history["time"]))):
-            rod_lines_2d.set_xdata(positions_over_time[t][0])
-            rod_lines_2d.set_ydata(positions_over_time[t][2])
-            writer.grab_frame()
-
-    plt.close(plt.gcf())
+    plot_dynamic_cantilever_video_with(mode, recorded_history, rendering_fps)

--- a/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
@@ -1,0 +1,102 @@
+import numpy as np
+from matplotlib import pyplot as plt
+from elastica import *
+from dynamic_cantilever import simulate_dynamic_cantilever_with
+
+
+class DynamicCantileverSimulator(BaseSystemCollection, Constraints, CallBacks):
+    pass
+
+
+cantilever_sim = DynamicCantileverSimulator()
+
+# Options
+PLOT_FIGURE = True
+SAVE_FIGURE = False
+PLOT_VIDEO = True
+
+# Add test parameters
+n_elem = 200
+final_time = 100
+rendering_fps = 30
+mode = 2
+
+sim_result = simulate_dynamic_cantilever_with(
+    density=500,
+    n_elem=n_elem,
+    final_time=final_time,
+    mode=mode,
+    rendering_fps=rendering_fps,
+)
+
+cantilever = sim_result["rod"]
+recorded_history = sim_result["recorded_history"]
+omegas = sim_result["fft_frequencies"]
+amps = sim_result["fft_amplitudes"]
+vibration = sim_result["vibration"]
+peak = sim_result["peak"]
+
+# End position time-dependent plot
+fig = plt.figure(figsize=(20, 8), frameon=True, dpi=150)
+ax = fig.add_subplot(121)
+ax.plot(
+    recorded_history["time"],
+    recorded_history["z_position"],
+    lw=2.0,
+    label="Cosserat rod model",
+)
+ax.set_xlabel("Time [s]", fontsize=16)
+ax.set_ylabel("Displacement [m]", fontsize=16)
+ax.grid(visible=True, which="both", color="k", linestyle="--")
+
+times = np.array(recorded_history["time"])
+
+positions = vibration.get_positions(1, times)
+ax.plot(times, positions, lw=2.0, label="Euler-Bernoulli beam theory")
+ax.legend()
+
+# FFT plot
+fft_ax = fig.add_subplot(122)
+fft_ax.plot(omegas, amps, lw=2, color="k")
+fft_ax.set_xlim([0, vibration.get_omega() * 2])
+
+fft_ax.set_xlabel("Frequency [rad/s]", fontsize=16)
+fft_ax.set_ylabel("Amplitude [m]", fontsize=16)
+
+fft_ax.plot(omegas[peak], amps[peak], "*", color="red", ms=8)
+
+if PLOT_FIGURE:
+    plt.show()
+
+if SAVE_FIGURE:
+    fig.savefig("Dynamic_cantilever_visualization.png")
+
+if PLOT_VIDEO:
+    print("Plotting video ...")
+    video_name = f"Dynamic_cantilever_mode_{mode+1}.mp4"
+
+    import matplotlib.animation as manimation
+    from tqdm import tqdm
+
+    positions_over_time = np.array(recorded_history["position"])
+
+    FFMpegWriter = manimation.writers["ffmpeg"]
+    metadata = dict(title="Movie Test", artist="Matplotlib", comment="Movie support!")
+    writer = FFMpegWriter(fps=rendering_fps, metadata=metadata)
+    mvfig = plt.figure(figsize=(10, 8), frameon=True, dpi=150)
+    ax = mvfig.add_subplot(111)
+    ax.set_xlim([0, 1.25])
+    ax.set_ylim([-0.02, 0.02])
+    ax.set_xlabel("x [m]", fontsize=16)
+    ax.set_ylabel("z [m]", fontsize=16)
+    rod_lines_2d = ax.plot(
+        positions_over_time[0][0], positions_over_time[0][2], lw=8, color="k"
+    )[0]
+
+    with writer.saving(mvfig, video_name, dpi=150):
+        for t in tqdm(range(1, len(recorded_history["time"]))):
+            rod_lines_2d.set_xdata(positions_over_time[t][0])
+            rod_lines_2d.set_ydata(positions_over_time[t][2])
+            writer.grab_frame()
+
+    plt.close(plt.gcf())

--- a/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
@@ -1,3 +1,5 @@
+__doc__ = """Visualization of simulated dynamic cantilever beam"""
+
 from elastica import *
 from dynamic_cantilever import simulate_dynamic_cantilever_with
 from dynamic_cantilever_post_processing import (

--- a/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
+++ b/examples/DynamicCantileverCase/dynamic_cantilever_visualization.py
@@ -37,7 +37,7 @@ cantilever = sim_result["rod"]
 recorded_history = sim_result["recorded_history"]
 omegas = sim_result["fft_frequencies"]
 amplitudes = sim_result["fft_amplitudes"]
-vibration = sim_result["vibration"]
+analytical_cantilever_soln = sim_result["analytical_cantilever_soln"]
 peak = sim_result["peak"]
 
 # Plotting end-point position over time
@@ -45,7 +45,7 @@ peak = sim_result["peak"]
 if PLOT_FIGURE or SAVE_FIGURE:
     plot_end_position_with(
         recorded_history,
-        vibration,
+        analytical_cantilever_soln,
         omegas,
         amplitudes,
         peak,

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,7 @@ Examples can serve as a starting template for customized usages.
     * __Purpose__: Demonstrate the usage of boundary conditions for constraining the movement of the system.
     * __Features__: GeneralConstraint, CosseratRod
 * [DynamicCantileverCase](./DynamicCantileverCase)
-    * __Purpose__: Physical validation of dynamic cantilever vibration at multiple modes.
+    * __Purpose__: Validation of dynamic cantilever vibration for multiple modes.
     * __Features__: CosseratRod, OneEndFixedRod
 
 ## Functional Examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,9 @@ Examples can serve as a starting template for customized usages.
 * [BoundaryConditionsCases](./BoundaryConditionsCases)
     * __Purpose__: Demonstrate the usage of boundary conditions for constraining the movement of the system.
     * __Features__: GeneralConstraint, CosseratRod
+* [DynamicCantileverCase](./DynamicCantileverCase)
+    * __Purpose__: Physical validation of dynamic cantilever vibration at multiple modes.
+    * __Features__: CosseratRod, OneEndFixedRod
 
 ## Functional Examples
 


### PR DESCRIPTION
Fixes #111 by adding a dynamic cantilever example.

The example compares the simulated response of cantilever, initialized by modal oscillations at natural frequencies, to [Euler-Bernoulli beam theory](https://en.wikipedia.org/wiki/Euler%E2%80%93Bernoulli_beam_theory#Dynamic_beam_equation). The comparison is made with respect to varying densities. 
![Dynamic_cantilever_phase_plot](https://user-images.githubusercontent.com/47127977/184692974-0a4f2805-0620-4214-9dc9-ef4f797e9676.png)

With a given set of parameters, the time-dependent response using the Cosserat model matches the theoretical response in both time and frequency domains (Left: time-dependent cantilever deflection at the tip. Right: corresponding FFT plot). 
![Dynamic_cantilever_visualization](https://user-images.githubusercontent.com/47127977/184692976-57d422e9-f9ca-47a4-9a60-861f00f9eef3.png)

The example supports modal oscillation up to the first four modes (example using the second mode).  

https://user-images.githubusercontent.com/47127977/184695082-90424c14-8cba-4529-b598-61de4510662e.mp4


