### PR TITLE
Refactor: change typings in forcing/constraints/connections to SystemType or RodType

### DIFF
--- a/elastica/boundary_conditions.py
+++ b/elastica/boundary_conditions.py
@@ -735,7 +735,7 @@ class HelicalBucklingBC(ConstraintBase):
             rod.director_collection[..., 0] = self.final_start_directors
             rod.director_collection[..., -1] = self.final_end_directors
 
-    def constrain_rates(self, rod: SystemType, time: float) -> None:
+    def constrain_rates(self, rod: RodType, time: float) -> None:
         if time > self.twisting_time:
             rod.velocity_collection[..., 0] = 0.0
             rod.omega_collection[..., 0] = 0.0

--- a/elastica/dissipation.py
+++ b/elastica/dissipation.py
@@ -63,8 +63,8 @@ class DamperBase(ABC):
 
         Parameters
         ----------
-        system : Union[Type[RodBase], Type[RigidBodyBase]]
-            Rod or rigid-body object.
+        system : SystemType
+            System (rod or rigid-body) object.
         time : float
             The time of simulation.
 
@@ -144,13 +144,13 @@ class AnalyticalLinearDamper(DamperBase):
             * np.diagonal(self._system.inv_mass_second_moment_of_inertia).T
         )
 
-    def dampen_rates(self, system: SystemType, time: float):
-        system.velocity_collection[:] = (
-            system.velocity_collection * self.translational_damping_coefficient
+    def dampen_rates(self, rod: RodType, time: float):
+        rod.velocity_collection[:] = (
+            rod.velocity_collection * self.translational_damping_coefficient
         )
 
-        system.omega_collection[:] = system.omega_collection * np.power(
-            self.rotational_damping_coefficient, system.dilatation
+        rod.omega_collection[:] = rod.omega_collection * np.power(
+            self.rotational_damping_coefficient, rod.dilatation
         )
 
 

--- a/elastica/dissipation.py
+++ b/elastica/dissipation.py
@@ -56,14 +56,14 @@ class DamperBase(ABC):
         return self._system
 
     @abstractmethod
-    def dampen_rates(self, rod: SystemType, time: float):
+    def dampen_rates(self, system: SystemType, time: float):
         # TODO: In the future, we can remove rod and use self.system
         """
         Dampen rates (velocity and/or omega) of a rod object.
 
         Parameters
         ----------
-        rod : Union[Type[RodBase], Type[RigidBodyBase]]
+        system : Union[Type[RodBase], Type[RigidBodyBase]]
             Rod or rigid-body object.
         time : float
             The time of simulation.
@@ -144,13 +144,13 @@ class AnalyticalLinearDamper(DamperBase):
             * np.diagonal(self._system.inv_mass_second_moment_of_inertia).T
         )
 
-    def dampen_rates(self, rod: SystemType, time: float):
-        rod.velocity_collection[:] = (
-            rod.velocity_collection * self.translational_damping_coefficient
+    def dampen_rates(self, system: SystemType, time: float):
+        system.velocity_collection[:] = (
+            system.velocity_collection * self.translational_damping_coefficient
         )
 
-        rod.omega_collection[:] = rod.omega_collection * np.power(
-            self.rotational_damping_coefficient, rod.dilatation
+        system.omega_collection[:] = system.omega_collection * np.power(
+            self.rotational_damping_coefficient, system.dilatation
         )
 
 

--- a/elastica/external_forces.py
+++ b/elastica/external_forces.py
@@ -1,4 +1,5 @@
-__doc__ = """ Numba implementation module for boundary condition implementations that apply external forces to the rod."""
+__doc__ = """ Numba implementation module for boundary condition implementations that apply
+external forces to the system."""
 __all__ = [
     "NoForces",
     "GravityForces",
@@ -11,6 +12,7 @@ __all__ = [
 
 import numpy as np
 from elastica._linalg import _batch_matvec
+from elastica.typing import SystemType, RodType
 from elastica.utils import _bspline
 
 import numba
@@ -35,15 +37,15 @@ class NoForces:
         """
         pass
 
-    def apply_forces(self, system, time: np.float64 = 0.0):
+    def apply_forces(self, system: SystemType, time: np.float64 = 0.0):
         """Apply forces to a rod-like object.
 
         In NoForces class, this routine simply passes.
 
         Parameters
         ----------
-        system : object
-            System that is Rod-like.
+        system : SystemType
+            Rod or rigid-body object
         time : float
             The time of simulation.
 
@@ -55,15 +57,15 @@ class NoForces:
 
         pass
 
-    def apply_torques(self, system, time: np.float64 = 0.0):
+    def apply_torques(self, system: SystemType, time: np.float64 = 0.0):
         """Apply torques to a rod-like object.
 
         In NoForces class, this routine simply passes.
 
         Parameters
         ----------
-        system : object
-            System that is Rod-like.
+        system : SystemType
+            Rod or rigid-body object
         time : float
             The time of simulation.
 
@@ -97,7 +99,7 @@ class GravityForces(NoForces):
         super(GravityForces, self).__init__()
         self.acc_gravity = acc_gravity
 
-    def apply_forces(self, system, time=0.0):
+    def apply_forces(self, system: SystemType, time=0.0):
         self.compute_gravity_forces(
             self.acc_gravity, system.mass, system.external_forces
         )
@@ -132,9 +134,9 @@ class EndpointForces(NoForces):
         Attributes
         ----------
         start_force: numpy.ndarray
-            1D (dim) array containing data with 'float' type. Force applied to first node of the rod-like object.
+            1D (dim) array containing data with 'float' type. Force applied to first node of the system.
         end_force: numpy.ndarray
-            1D (dim) array containing data with 'float' type. Force applied to last node of the rod-like object.
+            1D (dim) array containing data with 'float' type. Force applied to last node of the system.
         ramp_up_time: float
             Applied forces are ramped up until ramp up time.
 
@@ -147,10 +149,10 @@ class EndpointForces(NoForces):
         ----------
         start_force: numpy.ndarray
             1D (dim) array containing data with 'float' type.
-            Force applied to first node of the rod-like object.
+            Force applied to first node of the system.
         end_force: numpy.ndarray
             1D (dim) array containing data with 'float' type.
-            Force applied to last node of the rod-like object.
+            Force applied to last node of the system.
         ramp_up_time: float
             Applied forces are ramped up until ramp up time.
 
@@ -161,7 +163,7 @@ class EndpointForces(NoForces):
         assert ramp_up_time > 0.0
         self.ramp_up_time = ramp_up_time
 
-    def apply_forces(self, system, time=0.0):
+    def apply_forces(self, system: SystemType, time=0.0):
         self.compute_end_point_forces(
             system.external_forces,
             self.start_force,
@@ -186,7 +188,7 @@ class EndpointForces(NoForces):
             1D (dim) array containing data with 'float' type.
         end_force: numpy.ndarray
             1D (dim) array containing data with 'float' type.
-            Force applied to last node of the rod-like object.
+            Force applied to last node of the system.
         time: float
         ramp_up_time: float
             Applied forces are ramped up until ramp up time.
@@ -225,7 +227,7 @@ class UniformTorques(NoForces):
         super(UniformTorques, self).__init__()
         self.torque = torque * direction
 
-    def apply_torques(self, system, time: np.float64 = 0.0):
+    def apply_torques(self, system: SystemType, time: np.float64 = 0.0):
         n_elems = system.n_elems
         torque_on_one_element = (
             _batch_product_i_k_to_ik(self.torque, np.ones((n_elems))) / n_elems
@@ -259,14 +261,14 @@ class UniformForces(NoForces):
         super(UniformForces, self).__init__()
         self.force = (force * direction).reshape(3, 1)
 
-    def apply_forces(self, system, time: np.float64 = 0.0):
-        force_on_one_element = self.force / system.n_elems
+    def apply_forces(self, rod: RodType, time: np.float64 = 0.0):
+        force_on_one_element = self.force / rod.n_elems
 
-        system.external_forces += force_on_one_element
+        rod.external_forces += force_on_one_element
 
         # Because mass of first and last node is half
-        system.external_forces[..., 0] -= 0.5 * force_on_one_element[:, 0]
-        system.external_forces[..., -1] -= 0.5 * force_on_one_element[:, 0]
+        rod.external_forces[..., 0] -= 0.5 * force_on_one_element[:, 0]
+        rod.external_forces[..., -1] -= 0.5 * force_on_one_element[:, 0]
 
 
 class MuscleTorques(NoForces):
@@ -372,7 +374,7 @@ class MuscleTorques(NoForces):
 
             self.my_spline = constant_function(self.s)
 
-    def apply_torques(self, system, time: np.float64 = 0.0):
+    def apply_torques(self, rod: RodType, time: np.float64 = 0.0):
         self.compute_muscle_torques(
             time,
             self.my_spline,
@@ -382,8 +384,8 @@ class MuscleTorques(NoForces):
             self.phase_shift,
             self.ramp_up_time,
             self.direction,
-            system.director_collection,
-            system.external_torques,
+            rod.director_collection,
+            rod.external_torques,
         )
 
     @staticmethod
@@ -512,17 +514,17 @@ class EndpointForcesSinusoidal(NoForces):
         Parameters
         ----------
         start_force_mag: float
-            Magnitude of the force that is applied to the start of the rod (node 0).
+            Magnitude of the force that is applied to the start of the system (node 0).
         end_force_mag: float
-            Magnitude of the force that is applied to the end of the rod (node -1).
+            Magnitude of the force that is applied to the end of the system (node -1).
         ramp_up_time: float
             Applied muscle torques are ramped up until ramp up time.
         tangent_direction: np.ndarray
             An array (3,) contains type float.
-            This is the tangent direction of the rod, or normal of the plane that forces applied.
+            This is the tangent direction of the system, or normal of the plane that forces applied.
         normal_direction: np.ndarray
             An array (3,) contains type float.
-            This is the normal direction of the rod.
+            This is the normal direction of the system.
         """
         super(EndpointForcesSinusoidal, self).__init__()
         # Start force
@@ -536,7 +538,7 @@ class EndpointForcesSinusoidal(NoForces):
         assert ramp_up_time >= 0.0
         self.ramp_up_time = ramp_up_time
 
-    def apply_forces(self, system, time=0.0):
+    def apply_forces(self, system: SystemType, time=0.0):
 
         if time < self.ramp_up_time:
             # When time smaller than ramp up time apply the force in normal direction

--- a/elastica/joint.py
+++ b/elastica/joint.py
@@ -2,6 +2,7 @@ __doc__ = """ Module containing joint classes to connect multiple rods together.
 __all__ = ["FreeJoint", "HingeJoint", "FixedJoint", "ExternalContact", "SelfContact"]
 from elastica._linalg import _batch_product_k_ik_to_ik
 from elastica._rotations import _inv_rotate
+from elastica.typing import SystemType, RodType
 from math import sqrt
 import numba
 import numpy as np
@@ -43,18 +44,20 @@ class FreeJoint:
         self.k = k
         self.nu = nu
 
-    def apply_forces(self, rod_one, index_one, rod_two, index_two):
+    def apply_forces(
+        self, system_one: SystemType, index_one, system_two: SystemType, index_two
+    ):
         """
         Apply joint force to the connected rod objects.
 
         Parameters
         ----------
-        rod_one : object
-            Rod-like object
+        system_one : object
+            Rod or rigid-body object
         index_one : int
             Index of first rod for joint.
-        rod_two : object
-            Rod-like object
+        system_two : object
+            Rod or rigid-body object
         index_two : int
             Index of second rod for joint.
 
@@ -63,24 +66,26 @@ class FreeJoint:
 
         """
         end_distance_vector = (
-            rod_two.position_collection[..., index_two]
-            - rod_one.position_collection[..., index_one]
+            system_two.position_collection[..., index_two]
+            - system_one.position_collection[..., index_one]
         )
         elastic_force = self.k * end_distance_vector
 
         relative_velocity = (
-            rod_two.velocity_collection[..., index_two]
-            - rod_one.velocity_collection[..., index_one]
+            system_two.velocity_collection[..., index_two]
+            - system_one.velocity_collection[..., index_one]
         )
         damping_force = self.nu * relative_velocity
 
         contact_force = elastic_force + damping_force
-        rod_one.external_forces[..., index_one] += contact_force
-        rod_two.external_forces[..., index_two] -= contact_force
+        system_one.external_forces[..., index_one] += contact_force
+        system_two.external_forces[..., index_two] -= contact_force
 
         return
 
-    def apply_torques(self, rod_one, index_one, rod_two, index_two):
+    def apply_torques(
+        self, system_one: SystemType, index_one, system_two: SystemType, index_two
+    ):
         """
         Apply restoring joint torques to the connected rod objects.
 
@@ -88,12 +93,12 @@ class FreeJoint:
 
         Parameters
         ----------
-        rod_one : object
-            Rod-like object
+        system_one : object
+            Rod or rigid-body object
         index_one : int
             Index of first rod for joint.
-        rod_two : object
-            Rod-like object
+        system_two : object
+            Rod or rigid-body object
         index_two : int
             Index of second rod for joint.
 
@@ -149,10 +154,22 @@ class HingeJoint(FreeJoint):
         self.kt = kt
 
     # Apply force is same as free joint
-    def apply_forces(self, system_one, index_one, system_two, index_two):
+    def apply_forces(
+        self,
+        system_one: SystemType,
+        index_one,
+        system_two: SystemType,
+        index_two,
+    ):
         return super().apply_forces(system_one, index_one, system_two, index_two)
 
-    def apply_torques(self, system_one, index_one, system_two, index_two):
+    def apply_torques(
+        self,
+        system_one: SystemType,
+        index_one,
+        system_two: SystemType,
+        index_two,
+    ):
         # current tangent direction of the `index_two` element of system two
         system_two_tangent = system_two.director_collection[2, :, index_two]
 
@@ -237,10 +254,22 @@ class FixedJoint(FreeJoint):
         self.rest_rotation_matrix = rest_rotation_matrix
 
     # Apply force is same as free joint
-    def apply_forces(self, rod_one, index_one, rod_two, index_two):
-        return super().apply_forces(rod_one, index_one, rod_two, index_two)
+    def apply_forces(
+        self,
+        system_one: SystemType,
+        index_one,
+        system_two: SystemType,
+        index_two,
+    ):
+        return super().apply_forces(system_one, index_one, system_two, index_two)
 
-    def apply_torques(self, system_one, index_one, system_two, index_two):
+    def apply_torques(
+        self,
+        system_one: SystemType,
+        index_one,
+        system_two: SystemType,
+        index_two,
+    ):
         # collect directors of systems one and two
         # note that systems can be either rods or rigid bodies
         system_one_director = system_one.director_collection[..., index_one]
@@ -283,7 +312,12 @@ class FixedJoint(FreeJoint):
         system_two.external_torques[..., index_two] += system_two_director @ torque
 
 
-def get_relative_rotation_two_systems(system_one, index_one, system_two, index_two):
+def get_relative_rotation_two_systems(
+    system_one: SystemType,
+    index_one,
+    system_two: SystemType,
+    index_two,
+):
     """
     Compute the relative rotation matrix C_12 between system one and system two at the specified elements.
 
@@ -291,17 +325,17 @@ def get_relative_rotation_two_systems(system_one, index_one, system_two, index_t
     ----------
     How to get the relative rotation between two systems (e.g. the rotation from end of rod one to base of rod two):
 
-        >>> rel_rot_mat = get_relative_rotation_two_systems(rod1, -1, rod2, 0)
+        >>> rel_rot_mat = get_relative_rotation_two_systems(system1, -1, system2, 0)
 
     How to initialize a FixedJoint with a rest rotation between the two systems,
     which is enforced throughout the simulation:
 
         >>> simulator.connect(
-        ...    first_rod=rod1, second_rod=rod2, first_connect_idx=-1, second_connect_idx=0
+        ...    first_rod=system1, second_rod=system2, first_connect_idx=-1, second_connect_idx=0
         ... ).using(
         ...    FixedJoint,
         ...    ku=1e6, nu=0.0, kt=1e3, nut=0.0,
-        ...    rest_rotation_matrix=get_relative_rotation_two_systems(rod1, -1, rod2, 0)
+        ...    rest_rotation_matrix=get_relative_rotation_two_systems(system1, -1, system2, 0)
         ... )
 
     See Also
@@ -310,12 +344,12 @@ def get_relative_rotation_two_systems(system_one, index_one, system_two, index_t
 
     Parameters
     ----------
-    rod_one : object
-        Rod-like object
+    system_one : SystemType
+        Rod or rigid-body object
     index_one : int
         Index of first rod for joint.
-    rod_two : object
-        Rod-like object
+    system_two : SystemType
+        Rod or rigid-body object
     index_two : int
         Index of second rod for joint.
 
@@ -921,7 +955,13 @@ class ExternalContact(FreeJoint):
         self.velocity_damping_coefficient = velocity_damping_coefficient
         self.friction_coefficient = friction_coefficient
 
-    def apply_forces(self, rod_one, index_one, rod_two, index_two):
+    def apply_forces(
+        self,
+        rod_one: RodType,
+        index_one,
+        rod_two: SystemType,
+        index_two,
+    ):
         # del index_one, index_two
 
         # TODO: raise error during the initialization if rod one is rigid body.
@@ -1019,7 +1059,7 @@ class SelfContact(FreeJoint):
     def __init__(self, k, nu):
         super().__init__(k, nu)
 
-    def apply_forces(self, rod_one, index_one, rod_two, index_two):
+    def apply_forces(self, rod_one: RodType, index_one, rod_two: SystemType, index_two):
         # del index_one, index_two
 
         _calculate_contact_forces_self_rod(


### PR DESCRIPTION
Fixes #174.

1. Removed all Union[Type[RodBase], Type[RigidBodyBase]] to typing.SystemType in boundary_condition.py and dissipation.py.
2. Changed 'rod' passed to arguments to 'system' where typing is 'SystemType'
3. Changed 'SystemType' in HelicalBucklingBC to RodType
4. AnalyticalLinearDamper class in dissipation.py remains applicable to SystemType, but RigidBodyBase doesn't have system.dilatation so it may raise an error

