### PR TITLE
(#152) Windows CI fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
             path: ~/.cache/pip
           - os: macos-latest
             path: ~/Library/Caches/pip
-#          - os: windows-latest
-#            path: ~\AppData\Local\pip\Cache
+          - os: windows-latest
+            path: ~\AppData\Local\pip\Cache
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest] #, windows-latest] # Run macos tests if really required, since they charge 10 times more for macos
+        os: [ubuntu-latest, macos-latest, windows-latest] # Run macos tests if really required, since they charge 10 times more for macos
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/tests/test_callback_functions.py
+++ b/tests/test_callback_functions.py
@@ -317,23 +317,28 @@ class TestExportCallBackClass:
 
             saved_path_name = callback.get_last_saved_path()
             assert os.path.exists(saved_path_name), "File does not exist"
-            list_test = np.load(saved_path_name)
-
-            assert_allclose(
-                list_test["time"], list_correct["time"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["step"], list_correct["step"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["position"], list_correct["position"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["velocity"], list_correct["velocity"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["directors"], list_correct["directors"], atol=Tolerance.atol()
-            )
+            with np.load(saved_path_name) as list_test:
+                assert_allclose(
+                    list_test["time"], list_correct["time"], atol=Tolerance.atol()
+                )
+                assert_allclose(
+                    list_test["step"], list_correct["step"], atol=Tolerance.atol()
+                )
+                assert_allclose(
+                    list_test["position"],
+                    list_correct["position"],
+                    atol=Tolerance.atol(),
+                )
+                assert_allclose(
+                    list_test["velocity"],
+                    list_correct["velocity"],
+                    atol=Tolerance.atol(),
+                )
+                assert_allclose(
+                    list_test["directors"],
+                    list_correct["directors"],
+                    atol=Tolerance.atol(),
+                )
 
     @pytest.mark.parametrize("n_elems", [2, 4, 16])
     def test_export_call_back_class_pickle_option(self, n_elems):
@@ -371,21 +376,26 @@ class TestExportCallBackClass:
 
             saved_path_name = callback.get_last_saved_path()
             assert os.path.exists(saved_path_name), "File does not exist"
-            file = open(saved_path_name, "rb")
-            list_test = pickle.load(file)
-
-            assert_allclose(
-                list_test["time"], list_correct["time"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["step"], list_correct["step"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["position"], list_correct["position"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["velocity"], list_correct["velocity"], atol=Tolerance.atol()
-            )
-            assert_allclose(
-                list_test["directors"], list_correct["directors"], atol=Tolerance.atol()
-            )
+            with open(saved_path_name, "rb") as file:
+                list_test = pickle.load(file)
+                assert_allclose(
+                    list_test["time"], list_correct["time"], atol=Tolerance.atol()
+                )
+                assert_allclose(
+                    list_test["step"], list_correct["step"], atol=Tolerance.atol()
+                )
+                assert_allclose(
+                    list_test["position"],
+                    list_correct["position"],
+                    atol=Tolerance.atol(),
+                )
+                assert_allclose(
+                    list_test["velocity"],
+                    list_correct["velocity"],
+                    atol=Tolerance.atol(),
+                )
+                assert_allclose(
+                    list_test["directors"],
+                    list_correct["directors"],
+                    atol=Tolerance.atol(),
+                )


### PR DESCRIPTION
Fixes #152. Fixed failing CI on Windows by refactoring file open calls, replaced by safe `with` context manager.