### PR TITLE
remove python 3.7 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest] # Run macos tests if really required, since they charge 10 times more for macos
         include:
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: [ "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest] # Run macos tests if really required, since they charge 10 times more for macos
         include:
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       # Install Poetry and dependencies
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.1
-        with:
-          version: 1.1.14
+        uses: snok/install-poetry@v1
       - name: Set up cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       # Install Poetry and dependencies
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v1.3.3
       - name: Set up cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,9 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       # Install Poetry and dependencies
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.3
       - name: Set up cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,9 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       # Install Poetry and dependencies
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v1.3.1
         with:
-          version: 1.3.3
+          version: 1.1.14
       - name: Set up cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Removing python 3.7 from CI since it creates some conflicts with some packages.