### PR TITLE
# 169: Replaced 'moviepy' with 'ffmpeg' for video generation

### DIFF
--- a/examples/Visualization/ContinuumSnakeVisualization/continuum_snake_render.py
+++ b/examples/Visualization/ContinuumSnakeVisualization/continuum_snake_render.py
@@ -17,7 +17,6 @@ from functools import partial
 from multiprocessing import Pool
 
 import numpy as np
-from moviepy.editor import ImageSequenceClip
 from scipy import interpolate
 from tqdm import tqdm
 
@@ -176,15 +175,10 @@ if __name__ == "__main__":
             )
             pbar.update()
 
-    # Create Video using moviepy
+    # Create Video using ffmpeg
     for view_name in stage_scripts.keys():
         imageset_path = os.path.join(OUTPUT_IMAGES_DIR, view_name)
-        imageset = [
-            os.path.join(imageset_path, path)
-            for path in os.listdir(imageset_path)
-            if path[-3:] == "png"
-        ]
-        imageset.sort()
+
         filename = OUTPUT_FILENAME + "_" + view_name + ".mp4"
-        clip = ImageSequenceClip(imageset, fps=FPS)
-        clip.write_videofile(filename, fps=FPS)
+
+        os.system(f"ffmpeg -r {FPS} -i {imageset_path}/frame_%04d.png {filename}")

--- a/examples/Visualization/README.md
+++ b/examples/Visualization/README.md
@@ -11,5 +11,4 @@ python continuum_snake_render.py  # Creates pov_snake_diag.mp4 and pov_snake_top
 
 ### Dependency
 - povray
-- moviepy
 - ffmpeg


### PR DESCRIPTION
Replaced the video generation functionality from moviepy to ffmpeg because it is much faster and makes it uniform among other examples.


Ps: The codebase was failing some callbacks checks on my local machine, but I believe they are unrelated to my modification.
