### PR TITLE
Fixing testing arguments

### DIFF
--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -121,11 +121,20 @@ def test_external_contact_rod_rigid_body_without_collision():
     mock_rigid_body = MockRigidBody()
     ext_contact = ExternalContact(k=1.0, nu=0.5)
     mock_rigid_body.position_collection = np.array([[400], [500], [600]])
+    mock_rod_external_forces_before_execution = mock_rod.external_forces
+    mock_rigid_body_external_forces_before_execution = mock_rigid_body.external_forces
+    mock_rigid_body_external_torques_before_execution = mock_rigid_body.external_torques
     ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
 
-    assert_allclose(mock_rod.external_forces, mock_rod.external_forces)
-    assert_allclose(mock_rigid_body.external_forces, mock_rigid_body.external_forces)
-    assert_allclose(mock_rigid_body.external_torques, mock_rigid_body.external_torques)
+    assert_allclose(mock_rod.external_forces, mock_rod_external_forces_before_execution)
+    assert_allclose(
+        mock_rigid_body.external_forces,
+        mock_rigid_body_external_forces_before_execution,
+    )
+    assert_allclose(
+        mock_rigid_body.external_torques,
+        mock_rigid_body_external_torques_before_execution,
+    )
 
 
 def test_external_contact_with_two_rods_with_collision():
@@ -183,18 +192,20 @@ def test_external_contact_with_two_rods_without_collision():
         ]
     )
     ext_contact = ExternalContact(k=1.0, nu=0.5)
+    mock_rod_one_external_forces_before_execution = mock_rod_one.external_forces
+    mock_rod_two_external_forces_before_execution = mock_rod_two.external_forces
     ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
 
     assert_allclose(
         mock_rod_one.external_forces,
-        mock_rod_one.external_forces,
+        mock_rod_one_external_forces_before_execution,
         rtol=tol,
         atol=tol,
     )
 
     assert_allclose(
         mock_rod_two.external_forces,
-        mock_rod_two.external_forces,
+        mock_rod_two_external_forces_before_execution,
         rtol=tol,
         atol=tol,
     )


### PR DESCRIPTION
Previously the assert cases were comparing the forces with themselves and not to a copy array before execution; this PR has fixed it.