### PR TITLE
Contact Unit tests authenticated

### DIFF
--- a/elastica/joint.py
+++ b/elastica/joint.py
@@ -571,7 +571,7 @@ def _calculate_contact_forces_rod_rigid_body(
             cylinder_total_contact_torques += np.cross(
                 moment_arm, 2.0 * net_contact_force
             )
-        elif i == n_points:
+        elif i == n_points - 1:
             external_forces_rod[..., i] -= 4 / 3 * net_contact_force
             external_forces_rod[..., i + 1] -= 2 / 3 * net_contact_force
             cylinder_total_contact_forces += 2.0 * net_contact_force

--- a/elastica/joint.py
+++ b/elastica/joint.py
@@ -692,7 +692,7 @@ def _calculate_contact_forces_rod_rod(
             if i == 0:
                 external_forces_rod_one[..., i] -= net_contact_force * 2 / 3
                 external_forces_rod_one[..., i + 1] -= net_contact_force * 4 / 3
-            elif i == n_points_rod_one:
+            elif i == n_points_rod_one - 1:
                 external_forces_rod_one[..., i] -= net_contact_force * 4 / 3
                 external_forces_rod_one[..., i + 1] -= net_contact_force * 2 / 3
             else:
@@ -702,7 +702,7 @@ def _calculate_contact_forces_rod_rod(
             if j == 0:
                 external_forces_rod_two[..., j] += net_contact_force * 2 / 3
                 external_forces_rod_two[..., j + 1] += net_contact_force * 4 / 3
-            elif j == n_points_rod_two:
+            elif j == n_points_rod_two - 1:
                 external_forces_rod_two[..., j] += net_contact_force * 4 / 3
                 external_forces_rod_two[..., j + 1] += net_contact_force * 2 / 3
             else:
@@ -780,7 +780,7 @@ def _calculate_contact_forces_self_rod(
             # if i == 0:
             #     external_forces_rod[...,i] -= net_contact_force *2/3
             #     external_forces_rod[...,i+1] -= net_contact_force * 4/3
-            if i == n_points_rod:
+            if i == n_points_rod - 1:
                 external_forces_rod[..., i] -= net_contact_force * 4 / 3
                 external_forces_rod[..., i + 1] -= net_contact_force * 2 / 3
             else:

--- a/tests/test_contact_common_functions.py
+++ b/tests/test_contact_common_functions.py
@@ -37,24 +37,41 @@ class TestDotProduct:
         vec2 = [2, 0, 0]
         dot_product = _dot_product(vec1, vec2)
         assert_allclose(dot_product, 2)
+        """Calcutlations :  vec1 . vect2
+                            [1, 0, 0] . [2, 0, 0]
+                            1*2 + 0*0 + 0*0
+                            2 (Answer)"""
 
         "test for perpendicular vectors"
         vec1 = [1, 0, 0]
         vec2 = [0, 1, 0]
         dot_product = _dot_product(vec1, vec2)
         assert_allclose(dot_product, 0)
+        """Calcutlations :  vec1 . vect2
+                            [1, 0, 0] . [0, 1, 0]
+                            1*0 + 0*1 + 0*0
+                            0 (Answer)"""
 
         "test for opposite vectors"
         vec1 = [1, 0, 0]
         vec2 = [-1, 0, 0]
         dot_product = _dot_product(vec1, vec2)
         assert_allclose(dot_product, -1)
+        """Calcutlations :  vec1 . vect2
+                            [1, 0, 0] . [-1, 0, 0]
+                            1*-1 + 0*0 + 0*0
+                            -1 (Answer)"""
 
-        "test for complex vectors"
+        "test for arbitrary vectors"
         vec1 = [1, -2, 3]
         vec2 = [-2, 1, 3]
         dot_product = _dot_product(vec1, vec2)
         assert_allclose(dot_product, 5)
+        """Calcutlations :  vec1 . vect2
+                            [1, -2, 3] . [-2, 1, 3]
+                            1*-2 + -2*1 + 3*3
+                            -2 - 2 + 9
+                            5 (Answer)"""
 
 
 def test_norm_with_verified_values():
@@ -66,21 +83,36 @@ def test_norm_with_verified_values():
     vec1 = [0, 0, 0]
     norm = _norm(vec1)
     assert_allclose(norm, 0)
+    """Calcutlations :  sqrt(0^2 + 0^2 + 0^2)
+                        sqrt(0 + 0 + 0)
+                        0 (Answer)"""
 
     "test for unit vector"
     vec1 = [1, 1, 1]
     norm = _norm(vec1)
     assert_allclose(norm, 1.7320508075688772)
+    """Calcutlations :  sqrt(1^2 + 1^2 + 1^2)
+                        sqrt(1 + 1 + 1)
+                        sqrt(3)
+                        1.7320508075688772 (Answer)"""
 
     "test for arbitrary natural number vector"
     vec1 = [1, 2, 3]
     norm = _norm(vec1)
     assert_allclose(norm, 3.7416573867739413)
+    """Calcutlations :  sqrt(1^2 + 2^2 + 3^2)
+                        sqrt(1 + 4 + 9)
+                        sqrt(14)
+                        3.7416573867739413 (Answer)"""
 
     "test for decimal values vector"
     vec1 = [0.001, 0.002, 0.003]
     norm = _norm(vec1)
     assert_allclose(norm, 0.0037416573867739412)
+    """Calcutlations :  sqrt(0.001^2 + 0.002^2 + 0.003^2)
+                        sqrt(0.000001 + 0.000004 + 0.000009)
+                        sqrt(0.000014)
+                        0.0037416573867739412 (Answer)"""
 
 
 @pytest.mark.parametrize(
@@ -91,7 +123,8 @@ def test_clip_with_verified_values(x, result):
 
     "Function to test the _clip function"
 
-    "Testing function with analytically verified values"
+    """_clip is a simple comparison function;
+       The tests are made to get _clip to return 'low', 'x', 'high' in the respective order"""
 
     low = 1.0
     high = 2.0
@@ -106,7 +139,7 @@ def test_out_of_bounds_with_verified_values(x, result):
 
     "Function to test the _out_of_bounds function"
 
-    "testing function with analytically verified values"
+    """_out_of_bounds returns 1 if x < low or x > high, else returns 0"""
 
     low = 1.0
     high = 2.0
@@ -121,41 +154,49 @@ def test_find_min_dist():
     "intersecting lines"
     x1 = np.array([0, 0, 0])
     e1 = np.array([1, 1, 1])
+    # line 1 starts along origin and points towards (1,1,1)
     x2 = np.array([0, 1, 0])
     e2 = np.array([1, 0, 1])
-    min_dist_vec, closestpointofline1, closestpointofline2 = _find_min_dist(
+    # line 2 starts along (0,1,0) and points towards (1,0,1)
+    min_dist_vec, contact_point_of_system2, contact_point_of_system1 = _find_min_dist(
         x1, e1, x2, e2
     )
     assert_allclose(min_dist_vec, [0, 0, 0])
-    assert_allclose(closestpointofline1, [1, 1, 1])
-    assert_allclose(closestpointofline2, [-1, -1, -1])
+    # since the lines intersect, the minimum distance is 0.
+    assert_allclose(contact_point_of_system2, [1, 1, 1])
+    # the contact point of line 2 and line 1 is (1,1,1)
+    assert_allclose(contact_point_of_system1, [-1, -1, -1])
+    # the function returns -1 for contact point of system 1 in case of intersecting lines
 
-    "arbitrary close lines"
-    tol = 1e-5
+    "non intersecting lines"
     x1 = np.array([0, 0, 0])
-    e1 = np.array([1, 1, 1])
-    x2 = np.array([0, 0, 1])
-    e2 = np.array([1.5, 2, 0])
-    min_dist_vec, closestpointofline1, closestpointofline2 = _find_min_dist(
-        x1, e1, x2, e2
-    )
-    assert_allclose(min_dist_vec, [-0.153846, 0.115385, 0.038462], rtol=tol, atol=tol)
-    assert_allclose(closestpointofline1, [0.807692, 1.076923, 1], rtol=tol, atol=tol)
-    assert_allclose(
-        closestpointofline2, [-0.961538, -0.961538, -0.961538], rtol=tol, atol=tol
-    )
-
-    "arbitrary away lines"
-    x1 = np.array([7, 0, 3.5])
     e1 = np.array([1, 0, 0])
-    x2 = np.array([0, 70, 0])
-    e2 = np.array([0, 0, 11.5])
-    min_dist_vec, closestpointofline1, closestpointofline2 = _find_min_dist(
+    # line 1 starts along origin and points towards (1,0,0)
+    x2 = np.array([0, 1, 0])
+    e2 = np.array([0, 0, 1])
+    # line 2 starts along (0,1,0) and points towards (0,0,1)
+    min_dist_vec, contact_point_of_system2, contact_point_of_system1 = _find_min_dist(
         x1, e1, x2, e2
     )
-    assert_allclose(min_dist_vec, [-7, 70, 0])
-    assert_allclose(closestpointofline1, [0, 70, 3.5])
-    assert_allclose(closestpointofline2, [7, 0, 3.5])
+    assert_allclose(min_dist_vec, [0, 1, 0])
+    # minimum distance is 1 unit(verified using GeoGebra 3D calculator visualisation)
+    assert_allclose(contact_point_of_system2, [0, 1, 0])
+    assert_allclose(contact_point_of_system1, [0, 0, 0])
+
+    "parallel lines"
+    x1 = np.array([0, 0, 0])
+    e1 = np.array([1, 0, 0])
+    # line 1 starts along origin and points towards (1,0,0)
+    x2 = np.array([0, 1, 0])
+    e2 = np.array([1, 1, 0])
+    # line 2 starts along (0,1,0) and points towards (1,1,0)
+    min_dist_vec, contact_point_of_system2, contact_point_of_system1 = _find_min_dist(
+        x1, e1, x2, e2
+    )
+    assert_allclose(min_dist_vec, [0, 1, 0])
+    # minimum distance is 1 unit(verified using GeoGebra 3D calculator visualisation)
+    assert_allclose(contact_point_of_system2, [0, 1, 0])
+    assert_allclose(contact_point_of_system1, [0, 0, 0])
 
 
 def test_aabbs_not_intersectin():
@@ -166,9 +207,12 @@ def test_aabbs_not_intersectin():
     " intersecting boxes"
     aabb_one = np.array([[0, 0], [0, 0], [0, 0]])
     aabb_two = np.array([[0, 0], [0, 0], [0, 0]])
+    "both boxes are overlapping perfectly thus intersecting"
     assert _aabbs_not_intersecting(aabb_one, aabb_two) == 0
 
     " non Intersecting boxes"
     aabb_one = np.array([[0, 1], [0, 1], [0, 1]])
+    "box one is a unit size cube in the first quadrant with origin as one of its vertices"
     aabb_two = np.array([[2, 3], [2, 3], [2, 3]])
+    "box two is a unit size cube in the first quadrant with (2,2,2) as the closest vertex to box 1"
     assert _aabbs_not_intersecting(aabb_one, aabb_two) == 1

--- a/tests/test_contact_specific_functions.py
+++ b/tests/test_contact_specific_functions.py
@@ -118,7 +118,7 @@ def test_prune_using_aabbs_rod_rod():
     "Testing function with analytically verified values"
 
     "Intersecting rod and rod"
-    """Since both the rods have same position, node's radius and lenght, they are overlapping/intersecting in 3D space."""
+    """Since both the rods have same position, node's radius and length, they are overlapping/intersecting in 3D space."""
     rod_one = MockRod()
     rod_two = MockRod()
     assert (
@@ -330,7 +330,7 @@ class TestCalculateContactForcesRodRod:
         assert_allclose(
             rod_one.external_forces,
             np.array(
-                [[0, -0.5, -0.5], [0, 0, 0], [0, 0, 0]],
+                [[0, -0.666666, -0.333333], [0, 0, 0], [0, 0, 0]],
             ),
             atol=1e-6,
         )
@@ -386,7 +386,7 @@ class TestCalculateContactForcesRodRod:
         assert_allclose(
             rod_one.external_forces,
             np.array(
-                [[0, -0.25, -0.25], [0, 0, 0], [0, 0, 0]],
+                [[0, -0.333333, -0.166666], [0, 0, 0], [0, 0, 0]],
             ),
             atol=1e-6,
         )
@@ -409,9 +409,9 @@ def test_calculate_contact_forces_self_rod():
     rod.n_elems = 3
     rod.position_collection = np.array([[1, 4, 4, 1], [0, 0, 1, 1], [0, 0, 0, 0]])
     rod.radius_collection = np.array([1, 1, 1])
-    rod.length_collection = np.array([3, 3, 3])
+    rod.length_collection = np.array([3, 1, 3])
     rod.tangent_collection = np.array(
-        [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        [[1.0, 0.0, -1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
     )
     rod.velocity_collection = np.array(
         [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
@@ -448,6 +448,8 @@ def test_calculate_contact_forces_self_rod():
     The net force is then divided to the nodes of the rod as per indices."""
     assert_allclose(
         rod.external_forces,
-        np.array([[0, 0, 0, 0], [-0.333333, -0.666666, 0.5, 0.5], [0, 0, 0, 0]]),
+        np.array(
+            [[0, 0, 0, 0], [-0.333333, -0.666666, 0.666666, 0.333333], [0, 0, 0, 0]]
+        ),
         atol=1e-6,
     )

--- a/tests/test_contact_specific_functions.py
+++ b/tests/test_contact_specific_functions.py
@@ -4,6 +4,7 @@ __doc__ = (
 
 import numpy as np
 from numpy.testing import assert_allclose
+from elastica.typing import RodBase, RigidBodyBase
 from elastica.joint import (
     _prune_using_aabbs_rod_rigid_body,
     _prune_using_aabbs_rod_rod,
@@ -13,54 +14,97 @@ from elastica.joint import (
 )
 
 
+def mock_rod_init(self):
+
+    "Initializing Rod"
+
+    """This is a small rod with 2 elements;
+    Initial Parameters:
+    radius = 1, length = 0.5,
+    tangent vector for both elements is (1, 0, 0),
+    stationary rod i.e velocity vector of each node is (0, 0, 0),
+    internal/external forces vectors are also (0, 0, 0)"""
+
+    self.n_elems = 2
+    self.position_collection = np.array([[1, 2], [0, 0], [0, 0]])
+    self.radius_collection = np.array([1, 1])
+    self.length_collection = np.array([0.5, 0.5])
+    self.tangent_collection = np.array([[1.0, 1.0], [0.0, 0.0], [0.0, 0.0]])
+    self.velocity_collection = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    self.internal_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    self.external_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+
+
+def mock_rigid_body_init(self):
+
+    "Initializing Rigid Body as a cylinder"
+
+    """This is a rigid body cylinder;,
+    Initial Parameters:
+    radius = 1, length = 2,
+    center positioned at origin i.e (0, 0, 0),
+    cylinder's upright in x,y,z plane thus the director array,
+    stationary cylinder i.e velocity vector is (0, 0, 0),
+    external forces and torques vectors are also (0, 0, 0)"""
+
+    self.n_elems = 1
+    self.position = np.array([[0], [0], [0]])
+    self.director = np.array(
+        [[[1.0], [0.0], [0.0]], [[0.0], [0.0], [1.0]], [[0.0], [0.0], [1.0]]]
+    )
+    self.radius = 1.0
+    self.length = 2.0
+    self.velocity_collection = np.array([[0.0], [0.0], [0.0]])
+    self.external_forces = np.array([[0.0], [0.0], [0.0]])
+    self.external_torques = np.array([[0.0], [0.0], [0.0]])
+
+
+MockRod = type("MockRod", (RodBase,), {"__init__": mock_rod_init})
+
+MockRigidBody = type(
+    "MockRigidBody", (RigidBodyBase,), {"__init__": mock_rigid_body_init}
+)
+
+
 def test_prune_using_aabbs_rod_rigid_body():
     "Function to test the prune using aabbs rod rigid body function"
 
     "Testing function with analytically verified values"
 
     "Intersecting rod and cylinder"
-    "dummy inputs were generated using chatgpt"
-    rod_one_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    rod_one_radius_collection = np.array([1.0, 0.5])
-    rod_one_length_collection = np.array([2.0, 1.0])
-    cylinder_position = np.array([[4], [5], [6]])
-    cylinder_director = np.array(
-        [[[1], [0], [0]], [[0], [0.707], [-0.707]], [[0], [0.707], [0.707]]]
-    )
-    cylinder_radius = 1.5
-    cylinder_length = 5.0
+
+    """Since both the initialized rod and cylinder are overlapping in 3D space at (1, 1, 1);
+    Hence they are intersectiong and the function should return 0"""
+    rod = MockRod()
+    cylinder = MockRigidBody()
     assert (
         _prune_using_aabbs_rod_rigid_body(
-            rod_one_position_collection,
-            rod_one_radius_collection,
-            rod_one_length_collection,
-            cylinder_position,
-            cylinder_director,
-            cylinder_radius,
-            cylinder_length,
+            rod.position_collection,
+            rod.radius_collection,
+            rod.length_collection,
+            cylinder.position,
+            cylinder.director,
+            cylinder.radius,
+            cylinder.length,
         )
         == 0
     )
 
     "Non - Intersecting rod and cylinder"
-    rod_one_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    rod_one_radius_collection = np.array([1.0, 0.5])
-    rod_one_length_collection = np.array([2.0, 1.0])
-    cylinder_position = np.array([[20], [3], [4]])
-    cylinder_director = np.array(
-        [[[1], [0], [0]], [[0], [0.707], [-0.707]], [[0], [0.707], [0.707]]]
-    )
-    cylinder_radius = 1.5
-    cylinder_length = 5.0
+    rod = MockRod()
+    cylinder = MockRigidBody()
+
+    """Changing the position of cylinder in 3D space so the rod and cylinder don't overlap/intersect."""
+    cylinder.position = np.array([[20], [3], [4]])
     assert (
         _prune_using_aabbs_rod_rigid_body(
-            rod_one_position_collection,
-            rod_one_radius_collection,
-            rod_one_length_collection,
-            cylinder_position,
-            cylinder_director,
-            cylinder_radius,
-            cylinder_length,
+            rod.position_collection,
+            rod.radius_collection,
+            rod.length_collection,
+            cylinder.position,
+            cylinder.director,
+            cylinder.radius,
+            cylinder.length,
         )
         == 1
     )
@@ -72,40 +116,32 @@ def test_prune_using_aabbs_rod_rod():
     "Testing function with analytically verified values"
 
     "Intersecting rod and rod"
-    "dummy inputs were generated using chatgpt"
-    rod_one_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    rod_one_radius_collection = np.array([1.0, 0.5])
-    rod_one_length_collection = np.array([2.0, 1.0])
-    rod_two_position_collection = np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]])
-    rod_two_radius_collection = np.array([0.8, 1.2])
-    rod_two_length_collection = np.array([1.5, 2.5])
+    """Since both the rods have same position, node's radius and lenght, they are overlapping/intersecting in 3D space."""
+    rod_one = MockRod()
+    rod_two = MockRod()
     assert (
         _prune_using_aabbs_rod_rod(
-            rod_one_position_collection,
-            rod_one_radius_collection,
-            rod_one_length_collection,
-            rod_two_position_collection,
-            rod_two_radius_collection,
-            rod_two_length_collection,
+            rod_one.position_collection,
+            rod_one.radius_collection,
+            rod_one.length_collection,
+            rod_two.position_collection,
+            rod_two.radius_collection,
+            rod_two.length_collection,
         )
         == 0
     )
 
     "Non - Intersecting rod and rod"
-    rod_one_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    rod_one_radius_collection = np.array([0.5, 0.3])
-    rod_one_length_collection = np.array([1, 2])
-    rod_two_position_collection = np.array([[15, 16, 17], [18, 19, 20], [21, 22, 23]])
-    rod_two_radius_collection = np.array([0.4, 0.2])
-    rod_two_length_collection = np.array([2, 3])
+    """Changing the position of rod_two in 3D space so the rod_one and rod_two don't overlap/intersect."""
+    rod_two.position_collection = np.array([[20, 21], [22, 23], [24, 25]])
     assert (
         _prune_using_aabbs_rod_rod(
-            rod_one_position_collection,
-            rod_one_radius_collection,
-            rod_one_length_collection,
-            rod_two_position_collection,
-            rod_two_radius_collection,
-            rod_two_length_collection,
+            rod_one.position_collection,
+            rod_one.radius_collection,
+            rod_one.length_collection,
+            rod_two.position_collection,
+            rod_two.radius_collection,
+            rod_two.length_collection,
         )
         == 1
     )
@@ -116,85 +152,42 @@ def test_claculate_contact_forces_rod_rigid_body():
 
     "Testing function with analytically verified values"
 
-    tol = 1e-5
-
     "initializing rod parameters"
-    rod_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    rod = MockRod()
     rod_element_position = 0.5 * (
-        rod_position_collection[..., 1:] + rod_position_collection[..., :-1]
-    )
-    rod_radius_collection = np.array([1.3, 0.5])
-    rod_length_collection = np.array([2.1, 0.9])
-    rod_tangent_collection = np.array([[0, -0.29], [-0.029, 1.12], [-1.04, -1.165]])
-
-    rod_internal_forces = np.array(
-        [
-            [0.59155762, -0.0059393, 0.39725841],
-            [-2.45916096, 0.81593963, 1.19209269],
-            [1.46996099, -0.52774132, -0.08287433],
-        ]
-    )
-    rod_external_forces = np.array(
-        [
-            [-1.55308218, 1.00714652, 2.04033497],
-            [-0.35890683, -0.22667242, -0.31385005],
-            [-0.66969949, -0.67150666, 0.17822428],
-        ]
-    )
-
-    rod_velocity_collection = np.array(
-        [
-            [-0.91917535, -1.04929632, -0.32208191],
-            [0.13459384, -1.77261144, -0.28656239],
-            [1.63574433, 0.31741648, 1.43917516],
-        ]
+        rod.position_collection[..., 1:] + rod.position_collection[..., :-1]
     )
 
     "initializing cylinder parameters"
-    cylinder_position = np.array([[4], [5], [6]])
-    cylinder_director = np.array(
-        [[[1], [0], [0]], [[0], [0.707], [-0.707]], [[0], [0.707], [0.707]]]
-    )
-    cylinder_radius = 1.5
-    cylinder_length = 5.0
+    cylinder = MockRigidBody()
     x_cyl = (
-        cylinder_position[..., 0] - 0.5 * cylinder_length * cylinder_director[2, :, 0]
-    )
-
-    cylinder_external_forces = np.array([[-0.27817918], [-0.04400299], [1.36401515]])
-
-    cylinder_external_torques = np.array([[-0.2338623], [-1.39748107], [0.31085926]])
-
-    cylinder_velocity_collection = np.array(
-        [
-            [0.63276313, -0.32444142, 0.61402734],
-            [-0.01528792, -0.28025795, 0.32799382],
-            [-2.22331567, -0.80881859, -0.82109278],
-        ]
+        cylinder.position[..., 0] - 0.5 * cylinder.length * cylinder.director[2, :, 0]
     )
 
     "initializing constants"
+    """Setting contact_k = 1 and other parameters to 0,
+    so the net forces becomes a function of contact forces only."""
     k = 1.0
-    nu = 0.5
-    velocity_damping_coefficient = 0.1
-    friction_coefficient = 0.2
+    nu = 0
+    velocity_damping_coefficient = 0
+    friction_coefficient = 0
 
     "Function call"
     _calculate_contact_forces_rod_rigid_body(
         rod_element_position,
-        rod_length_collection * rod_tangent_collection,
-        cylinder_position[..., 0],
+        rod.length_collection * rod.tangent_collection,
+        cylinder.position[..., 0],
         x_cyl,
-        cylinder_length * cylinder_director[2, :, 0],
-        rod_radius_collection + cylinder_radius,
-        rod_length_collection + cylinder_length,
-        rod_internal_forces,
-        rod_external_forces,
-        cylinder_external_forces,
-        cylinder_external_torques,
-        cylinder_director[:, :, 0],
-        rod_velocity_collection,
-        cylinder_velocity_collection,
+        cylinder.length * cylinder.director[2, :, 0],
+        rod.radius_collection + cylinder.radius,
+        rod.length_collection + cylinder.length,
+        rod.internal_forces,
+        rod.external_forces,
+        cylinder.external_forces,
+        cylinder.external_torques,
+        cylinder.director[:, :, 0],
+        rod.velocity_collection,
+        cylinder.velocity_collection,
         k,
         nu,
         velocity_damping_coefficient,
@@ -202,29 +195,15 @@ def test_claculate_contact_forces_rod_rigid_body():
     )
 
     "Test values"
+    """The two systems were placed such that they are penetrating and
+    resulting forces act along the x-axis only.
+    The net force was calculated by halving the contact force i.e net force = 0.5 * contact force = -0.25;
+                                                                    where, contact force = k(1) * penetration depth(-1) * gamma(0.5) = -0.5
+    The net force is then divided to the nodes of the rod and the cylinder as per indices."""
+    assert_allclose(cylinder.external_forces, np.array([[-0.5], [0], [0]]))
+    assert_allclose(cylinder.external_torques, np.array([[0], [0], [0]]))
     assert_allclose(
-        cylinder_external_forces,
-        np.array([[-1.389433], [-0.180767], [1.662106]]),
-        rtol=tol,
-        atol=tol,
-    )
-    assert_allclose(
-        cylinder_external_torques,
-        np.array([[0.159707], [-2.261999], [0.310859]]),
-        rtol=tol,
-        atol=tol,
-    )
-    assert_allclose(
-        rod_external_forces,
-        np.array(
-            [
-                [-1.383582, 1.647523, 2.341712],
-                [-0.350649, -0.154162, -0.257856],
-                [-0.702578, -0.836991, 0.078497],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        rod.external_forces, np.array([[0.16, 0.33], [0, 0], [0, 0]]), atol=1e-2
     )
 
 
@@ -233,117 +212,49 @@ def test_calculate_contact_forces_rod_rod():
 
     "Testing function with analytically verified values"
 
-    tol = 1e-5
+    rod_one = MockRod()
 
-    "initializing rod 1 parameters"
-    rod_one_position_collection = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    rod_one_radius_collection = np.array([1.3, 0.5])
-    rod_one_length_collection = np.array([2.1, 0.9])
-    rod_one_tangent_collection = np.array([[0, -0.29], [-0.029, 1.12], [-1.04, -1.165]])
-
-    rod_one_internal_forces = np.array(
-        [
-            [0.59155762, -0.0059393, 0.39725841],
-            [-2.45916096, 0.81593963, 1.19209269],
-            [1.46996099, -0.52774132, -0.08287433],
-        ]
-    )
-    rod_one_external_forces = np.array(
-        [
-            [-1.55308218, 1.00714652, 2.04033497],
-            [-0.35890683, -0.22667242, -0.31385005],
-            [-0.66969949, -0.67150666, 0.17822428],
-        ]
-    )
-
-    rod_one_velocity_collection = np.array(
-        [
-            [-0.91917535, -1.04929632, -0.32208191],
-            [0.13459384, -1.77261144, -0.28656239],
-            [1.63574433, 0.31741648, 1.43917516],
-        ]
-    )
-
-    "initializing rod 2 parameters"
-    rod_two_position_collection = np.array(
-        [[1.0000001, 2.0000034, 3], [4, 5, 6], [7, 8, 9]]
-    )
-    rod_two_radius_collection = np.array([2.3, 0.4])
-    rod_two_length_collection = np.array([1.5, 1.0])
-    rod_two_tangent_collection = np.array([[0, -0.39], [-0.29, 1.00], [-1.0, -0.165]])
-
-    rod_two_internal_forces = np.array(
-        [
-            [-0.46552762, 1.16896583, 1.06695832],
-            [0.35104219, 0.5868144, -0.79542854],
-            [1.90896989, -1.7709093, 1.21209849],
-        ]
-    )
-    rod_two_external_forces = np.array(
-        [
-            [0.12615472, -0.12539237, -1.01333332],
-            [0.7193244, 1.12085914, 1.57535336],
-            [1.79006353, 0.20498294, 1.11384582],
-        ]
-    )
-
-    rod_two_velocity_collection = np.array(
-        [
-            [-1.09200111, -0.87381467, 0.44073417],
-            [0.93961598, 1.25513012, 0.09103194],
-            [1.02214026, -0.78790631, -0.74019659],
-        ]
-    )
+    rod_two = MockRod()
+    """Placing rod two such that its first element pentrates the second element of rod one
+    by 1.0 unit in the x-direction."""
+    rod_two.position_collection = np.array([[2.5, 3.5], [0, 0], [0, 0]])
 
     "initializing constants"
+    """Setting contact_k = 1 and nu to 0,
+    so the net forces becomes a function of contact forces only."""
     k = 1.0
-    nu = 0.5
+    nu = 0.0
 
     "Function call"
     _calculate_contact_forces_rod_rod(
-        rod_one_position_collection[..., :-1],
-        rod_one_radius_collection,
-        rod_one_length_collection,
-        rod_one_tangent_collection,
-        rod_one_velocity_collection,
-        rod_one_internal_forces,
-        rod_one_external_forces,
-        rod_two_position_collection[..., :-1],
-        rod_two_radius_collection,
-        rod_two_length_collection,
-        rod_two_tangent_collection,
-        rod_two_velocity_collection,
-        rod_two_internal_forces,
-        rod_two_external_forces,
+        rod_one.position_collection[..., :-1],
+        rod_one.radius_collection,
+        rod_one.length_collection,
+        rod_one.tangent_collection,
+        rod_one.velocity_collection,
+        rod_one.internal_forces,
+        rod_one.external_forces,
+        rod_two.position_collection[..., :-1],
+        rod_two.radius_collection,
+        rod_two.length_collection,
+        rod_two.tangent_collection,
+        rod_two.velocity_collection,
+        rod_two.internal_forces,
+        rod_two.external_forces,
         k,
         nu,
     )
 
     "Test values"
+    """Resulting forces act along the x-axis only.
+    The net force was calculated by halving the contact force i.e net force = 0.5 * contact force = 0.5;
+                                                                    where, contact force = k(1) * penetration depth(1) * gamma(1) = 1
+    The net force is then divided to the nodes of the rod and the cylinder as per indices."""
     assert_allclose(
-        rod_one_external_forces,
-        np.array(
-            [
-                [-2.752861, -2.349062, 1.083684],
-                [-0.358907, 0.627338, 0.54016],
-                [-0.669699, 0.387652, 1.237383],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        rod_one.external_forces, np.array([[-0.33, -0.66], [0, 0], [0, 0]]), atol=1e-2
     )
-
     assert_allclose(
-        rod_two_external_forces,
-        np.array(
-            [
-                [0.23889, 2.687294, 1.573883],
-                [-0.565314, -0.37547, 2.648301],
-                [0.825641, -1.336387, 1.501321],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        rod_two.external_forces, np.array([[0.33, 0.66], [0, 0], [0, 0]]), atol=1e-2
     )
 
 
@@ -352,69 +263,51 @@ def test_calculate_contact_forces_self_rod():
 
     "Testing function with analytically verified values"
 
-    tol = 1e-5
-
-    "initializing rod parameters"
-    rod_position_collection = np.array(
-        [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15]]
+    rod = MockRod()
+    """Increasing rod elements and length to establish self contact in rod;
+    elements are placed such that they are penetrating the next to next element by 1.0 unit in the x-direction."""
+    rod.n_elems = 4
+    rod.position_collection = np.array([[1, 3, 5, 7], [0, 0, 0, 0], [0, 0, 0, 0]])
+    rod.radius_collection = np.array([1, 1, 1, 1])
+    rod.length_collection = np.array([3.0, 3.0, 3.0, 3.0])
+    rod.tangent_collection = np.array(
+        [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
     )
-    rod_radius_collection = np.array(
-        [5.12952263, 0.19493561, 0.72904683, 0.21676892, 0.18705351]
+    rod.velocity_collection = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
     )
-    rod_length_collection = np.array(
-        [0.89050271, 0.7076813, 0.21078658, 0.95372826, 0.86037329]
+    rod.internal_forces = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
     )
-
-    rod_tangent_collection = np.array(
-        [
-            [-0.92511524, 0.19778438, 0.42897242, 0.28430662, -0.57637184],
-            [1.73622348, 1.55757074, -0.4606567, -1.30228854, -0.34647765],
-            [0.61561226, -0.86529598, -0.9180072, 0.99279484, -2.09424394],
-        ]
-    )
-
-    rod_external_forces = np.array(
-        [
-            [-0.77306421, -0.25648047, -0.93419262, -0.77665042, -0.33345937],
-            [-1.04834225, -1.92250527, -1.46505411, -0.71192403, -0.99256648],
-            [0.33465609, 1.22871475, 0.06250578, -0.49531749, 0.58044695],
-        ]
-    )
-
-    rod_velocity_collection = np.array(
-        [
-            [0.70544082, 0.05240655, -1.93283144, -0.35381074, -0.1305802],
-            [-0.15193337, -0.16199143, 0.94085659, 0.53076711, 2.15766298],
-            [-0.60888955, 0.36362709, 1.31370542, -0.7457939, -0.78005834],
-        ]
+    rod.external_forces = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
     )
 
     "initializing constants"
+    """Setting contact_k = 1 and nu to 0,
+    so the net forces becomes a function of contact forces only."""
     k = 1.0
-    nu = 0.5
+    nu = 0.0
 
     "Function call"
     _calculate_contact_forces_self_rod(
-        rod_position_collection[..., :-1],
-        rod_radius_collection,
-        rod_length_collection,
-        rod_tangent_collection,
-        rod_velocity_collection,
-        rod_external_forces,
+        rod.position_collection[..., :-1],
+        rod.radius_collection,
+        rod.length_collection,
+        rod.tangent_collection,
+        rod.velocity_collection,
+        rod.external_forces,
         k,
         nu,
     )
 
     "Test values"
+    """Resulting forces act along the x-axis only.
+    The net force was calculated by halving the contact force i.e net force = 0.5 * contact force = -0.5;
+                                                                    where, contact force = k(1) * penetration depth(-1) * gamma(1) = -1
+    The net force is then divided to the nodes of the rod and the cylinder as per indices."""
     assert_allclose(
-        rod_external_forces,
-        np.array(
-            [
-                [-0.976629, -0.663611, -0.934193, -0.471303, -0.028112],
-                [-1.125742, -2.077304, -1.465054, -0.595825, -0.876467],
-                [0.204132, 0.967667, 0.062506, -0.299531, 0.776233],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        rod.external_forces,
+        np.array([[-0.33, -0.66, 0.5, 0.5], [0, 0, 0, 0], [0, 0, 0, 0]]),
+        atol=1e-2,
     )

--- a/tests/test_contact_specific_functions.py
+++ b/tests/test_contact_specific_functions.py
@@ -18,12 +18,14 @@ def mock_rod_init(self):
 
     "Initializing Rod"
 
-    """This is a small rod with 2 elements;
+    """
+    This is a small rod with 2 elements;
     Initial Parameters:
     element's radius = 1, length = 1,
     tangent vector for both elements is (1, 0, 0),
     stationary rod i.e velocity vector of each node is (0, 0, 0),
-    internal/external forces vectors are also (0, 0, 0)"""
+    internal/external forces vectors are also (0, 0, 0)
+    """
 
     self.n_elems = 2
     self.position_collection = np.array([[1, 2, 3], [0, 0, 0], [0, 0, 0]])
@@ -41,13 +43,15 @@ def mock_rigid_body_init(self):
 
     "Initializing Rigid Body as a cylinder"
 
-    """This is a rigid body cylinder;,
+    """
+    This is a rigid body cylinder;,
     Initial Parameters:
     radius = 1, length = 2,
     center positioned at origin i.e (0, 0, 0),
     cylinder's upright in x,y,z plane thus the director array,
     stationary cylinder i.e velocity vector is (0, 0, 0),
-    external forces and torques vectors are also (0, 0, 0)"""
+    external forces and torques vectors are also (0, 0, 0)
+    """
 
     self.n_elems = 1
     self.position = np.array([[0], [0], [0]])
@@ -75,8 +79,10 @@ def test_prune_using_aabbs_rod_rigid_body():
 
     "Intersecting rod and cylinder"
 
-    """Since both the initialized rod and cylinder are overlapping in 3D space at (1, 1, 1);
-    Hence they are intersectiong and the function should return 0"""
+    """
+    Since both the initialized rod and cylinder are overlapping in 3D space at (1, 1, 1);
+    Hence they are intersectiong and the function should return 0
+    """
     rod = MockRod()
     cylinder = MockRigidBody()
     assert (
@@ -96,7 +102,9 @@ def test_prune_using_aabbs_rod_rigid_body():
     rod = MockRod()
     cylinder = MockRigidBody()
 
-    """Changing the position of cylinder in 3D space so the rod and cylinder don't overlap/intersect."""
+    """
+    Changing the position of cylinder in 3D space so the rod and cylinder don't overlap/intersect.
+    """
     cylinder.position = np.array([[20], [3], [4]])
     assert (
         _prune_using_aabbs_rod_rigid_body(
@@ -118,7 +126,9 @@ def test_prune_using_aabbs_rod_rod():
     "Testing function with analytically verified values"
 
     "Intersecting rod and rod"
-    """Since both the rods have same position, node's radius and length, they are overlapping/intersecting in 3D space."""
+    """
+    Since both the rods have same position, node's radius and length, they are overlapping/intersecting in 3D space.
+    """
     rod_one = MockRod()
     rod_two = MockRod()
     assert (
@@ -134,7 +144,9 @@ def test_prune_using_aabbs_rod_rod():
     )
 
     "Non - Intersecting rod and rod"
-    """Changing the position of rod_two in 3D space so the rod_one and rod_two don't overlap/intersect."""
+    """
+    Changing the position of rod_two in 3D space so the rod_one and rod_two don't overlap/intersect.
+    """
     rod_two.position_collection = np.array([[20, 21, 22], [0, 0, 0], [0, 0, 0]])
     assert (
         _prune_using_aabbs_rod_rod(
@@ -170,8 +182,10 @@ class TestCalculateContactForcesRodRigidBody:
         )
 
         "initializing constants"
-        """Setting contact_k = 1 and other parameters to 0,
-        so the net forces becomes a function of contact forces only."""
+        """
+        Setting contact_k = 1 and other parameters to 0,
+        so the net forces becomes a function of contact forces only.
+        """
         k = 1.0
         nu = 0
         velocity_damping_coefficient = 0
@@ -200,12 +214,14 @@ class TestCalculateContactForcesRodRigidBody:
         )
 
         "Test values"
-        """The two systems were placed such that they are penetrating by 0.5 units and
+        """
+        The two systems were placed such that they are penetrating by 0.5 units and
         resulting forces act along the x-axis only.
         The net force was calculated by halving the contact force i.e
                                                 net force = 0.5 * contact force = -0.25;
                                                     where, contact force = k(1) * min distance between colliding elements(-1) * gamma(0.5) = -0.5
-        The net force is then divided to the nodes of the rod and the cylinder as per indices."""
+        The net force is then divided to the nodes of the rod and the cylinder as per indices.
+        """
         assert_allclose(
             cylinder.external_forces, np.array([[-0.5], [0], [0]]), atol=1e-6
         )
@@ -236,8 +252,10 @@ class TestCalculateContactForcesRodRigidBody:
         )
 
         "initializing constants"
-        """Setting contact_nu = 1 and other parameters to 0,
-        so the net forces becomes a function of contact damping forces only."""
+        """
+        Setting contact_nu = 1 and other parameters to 0,
+        so the net forces becomes a function of contact damping forces only.
+        """
         k = 0.0
         nu = 1.0
         velocity_damping_coefficient = 0
@@ -266,12 +284,14 @@ class TestCalculateContactForcesRodRigidBody:
         )
 
         "Test values"
-        """The two systems were placed such that they are penetrating by 0.5 units and
+        """
+        The two systems were placed such that they are penetrating by 0.5 units and
         resulting forces act along the x-axis only.
         The net force was calculated by halving the contact damping force i.e
                                                 net force = 0.5 * contact damping force = -0.75;
                                                     where, contact damping force = -nu(1) * penetration velocity(1.5)[x-axis] = -1.5
-        The net force is then divided to the nodes of the rod and the cylinder as per indices."""
+        The net force is then divided to the nodes of the rod and the cylinder as per indices.
+        """
         assert_allclose(
             cylinder.external_forces, np.array([[-1.5], [0], [0]]), atol=1e-6
         )
@@ -279,6 +299,69 @@ class TestCalculateContactForcesRodRigidBody:
         assert_allclose(
             rod.external_forces,
             np.array([[0.5, 1, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+    def test_claculate_contact_forces_rod_rigid_body_with_k_and_nu(self):
+
+        "initializing rod parameters"
+        rod = MockRod()
+        "Moving rod towards the cylinder with a velocity of -1 in x-axis"
+        rod.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
+        rod_element_position = 0.5 * (
+            rod.position_collection[..., 1:] + rod.position_collection[..., :-1]
+        )
+
+        "initializing cylinder parameters"
+        cylinder = MockRigidBody()
+        "Moving cylinder towards the rod with a velocity of 1 in x-axis"
+        cylinder.velocity_collection = np.array([[1], [0], [0]])
+        x_cyl = (
+            cylinder.position[..., 0]
+            - 0.5 * cylinder.length * cylinder.director[2, :, 0]
+        )
+
+        "initializing constants"
+        """
+        Setting contact_nu = 1 and contact_k = 1,
+        so the net forces becomes a function of contact damping and contact forces.
+        """
+        k = 1.0
+        nu = 1.0
+        velocity_damping_coefficient = 0
+        friction_coefficient = 0
+
+        "Function call"
+        _calculate_contact_forces_rod_rigid_body(
+            rod_element_position,
+            rod.length_collection * rod.tangent_collection,
+            cylinder.position[..., 0],
+            x_cyl,
+            cylinder.length * cylinder.director[2, :, 0],
+            rod.radius_collection + cylinder.radius,
+            rod.length_collection + cylinder.length,
+            rod.internal_forces,
+            rod.external_forces,
+            cylinder.external_forces,
+            cylinder.external_torques,
+            cylinder.director[:, :, 0],
+            rod.velocity_collection,
+            cylinder.velocity_collection,
+            k,
+            nu,
+            velocity_damping_coefficient,
+            friction_coefficient,
+        )
+
+        "Test values"
+        """
+        For nu and k dependent case, we just have to add both the forces that were generated above.
+        """
+        assert_allclose(cylinder.external_forces, np.array([[-2], [0], [0]]), atol=1e-6)
+        assert_allclose(cylinder.external_torques, np.array([[0], [0], [0]]), atol=1e-6)
+        assert_allclose(
+            rod.external_forces,
+            np.array([[0.666666, 1.333333, 0], [0, 0, 0], [0, 0, 0]]),
             atol=1e-6,
         )
 
@@ -296,8 +379,10 @@ class TestCalculateContactForcesRodRod:
         rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
 
         "initializing constants"
-        """Setting contact_k = 1 and nu to 0,
-        so the net forces becomes a function of contact forces only."""
+        """
+        Setting contact_k = 1 and nu to 0,
+        so the net forces becomes a function of contact forces only.
+        """
         k = 1.0
         nu = 0.0
 
@@ -322,11 +407,13 @@ class TestCalculateContactForcesRodRod:
         )
 
         "Test values"
-        """Resulting forces act along the x-axis only.
+        """
+        Resulting forces act along the x-axis only.
         The net force was calculated by halving the contact force i.e
                                                 net force = 0.5 * contact force = 0.5;
                                                     where, contact force = k(1) * min distance between colliding elements(1) * gamma(1) = 1
-        The net force is then divided to the nodes of the two rods as per indices."""
+        The net force is then divided to the nodes of the two rods as per indices.
+        """
         assert_allclose(
             rod_one.external_forces,
             np.array(
@@ -352,8 +439,10 @@ class TestCalculateContactForcesRodRod:
         rod_two.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
 
         "initializing constants"
-        """Setting contact_nu = 1 and nu to 0,
-        so the net forces becomes a function of contact damping forces only."""
+        """
+        Setting contact_nu = 1 and nu to 0,
+        so the net forces becomes a function of contact damping forces only.
+        """
         k = 0.0
         nu = 1.0
 
@@ -378,11 +467,13 @@ class TestCalculateContactForcesRodRod:
         )
 
         "Test values"
-        """Resulting forces act along the x-axis only.
+        """
+        Resulting forces act along the x-axis only.
         The net force was calculated by halving the contact damping force i.e
                                                 net force = 0.5 * contact damping force = 0.25;
                                                     where, contact damping force = nu(1) * penetration velocity(0.5)[x-axis] = 0.5
-        The net force is then divided to the nodes of the two rods as per indices."""
+        The net force is then divided to the nodes of the two rods as per indices.
+        """
         assert_allclose(
             rod_one.external_forces,
             np.array(
@@ -393,6 +484,62 @@ class TestCalculateContactForcesRodRod:
         assert_allclose(
             rod_two.external_forces,
             np.array([[0.166666, 0.333333, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+    def test_calculate_contact_forces_rod_rod_with_k_and_nu(self):
+
+        rod_one = MockRod()
+        rod_two = MockRod()
+        """Placing rod two such that its first element just touches the last element of rod one."""
+        rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
+
+        """Moving the rods towards each other with a velocity of 1 along the x-axis."""
+        rod_one.velocity_collection = np.array([[1, 0, 0], [1, 0, 0], [1, 0, 0]])
+        rod_two.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
+
+        "initializing constants"
+        """
+        Setting contact_nu = 1 and contact_k = 1,
+        so the net forces becomes a function of contact damping and contact forces.
+        """
+        k = 1.0
+        nu = 1.0
+
+        "Function call"
+        _calculate_contact_forces_rod_rod(
+            rod_one.position_collection[..., :-1],
+            rod_one.radius_collection,
+            rod_one.length_collection,
+            rod_one.tangent_collection,
+            rod_one.velocity_collection,
+            rod_one.internal_forces,
+            rod_one.external_forces,
+            rod_two.position_collection[..., :-1],
+            rod_two.radius_collection,
+            rod_two.length_collection,
+            rod_two.tangent_collection,
+            rod_two.velocity_collection,
+            rod_two.internal_forces,
+            rod_two.external_forces,
+            k,
+            nu,
+        )
+
+        "Test values"
+        """
+        For nu and k dependent case, we just have to add both the forces that were generated above.
+        """
+        assert_allclose(
+            rod_one.external_forces,
+            np.array(
+                [[0, -1, -0.5], [0, 0, 0], [0, 0, 0]],
+            ),
+            atol=1e-6,
+        )
+        assert_allclose(
+            rod_two.external_forces,
+            np.array([[0.5, 1, 0], [0, 0, 0], [0, 0, 0]]),
             atol=1e-6,
         )
 

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -100,6 +100,34 @@ class TestExternalContact:
             mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
         )
 
+    def test_external_contact_rod_rigid_body_with_collision_with_k_and_nu(self):
+
+        "Testing External Contact wrapper with Collision with analytical verified values"
+
+        mock_rod = MockRod()
+        "Moving rod towards the cylinder with a velocity of -1 in x-axis"
+        mock_rod.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
+        mock_rigid_body = MockRigidBody()
+        "Moving cylinder towards the rod with a velocity of 1 in x-axis"
+        mock_rigid_body.velocity_collection = np.array([[1], [0], [0]])
+        ext_contact = ExternalContact(k=1.0, nu=1.0)
+        ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+
+        """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
+        assert_allclose(
+            mock_rod.external_forces,
+            np.array([[0.666666, 1.333333, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_forces, np.array([[-2], [0], [0]]), atol=1e-6
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
+        )
+
     def test_external_contact_rod_rigid_body_without_collision(self):
 
         "Testing External Contact wrapper without Collision with analytical verified values"
@@ -180,6 +208,36 @@ class TestExternalContact:
         assert_allclose(
             mock_rod_two.external_forces,
             np.array([[0.166666, 0.333333, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+    def test_external_contact_with_two_rods_with_collision_with_k_and_nu(self):
+
+        "Testing External Contact wrapper with two rods with analytical verified values"
+        "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_rod_rod()'"
+
+        mock_rod_one = MockRod()
+        mock_rod_two = MockRod()
+
+        """Moving the rods towards each other with a velocity of 1 along the x-axis."""
+        mock_rod_one.velocity_collection = np.array([[1, 0, 0], [1, 0, 0], [1, 0, 0]])
+        mock_rod_two.velocity_collection = np.array(
+            [[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]]
+        )
+        mock_rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
+        ext_contact = ExternalContact(k=1.0, nu=1.0)
+        ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
+
+        assert_allclose(
+            mock_rod_one.external_forces,
+            np.array(
+                [[0, -1, -0.5], [0, 0, 0], [0, 0, 0]],
+            ),
+            atol=1e-6,
+        )
+        assert_allclose(
+            mock_rod_two.external_forces,
+            np.array([[0.5, 1, 0], [0, 0, 0], [0, 0, 0]]),
             atol=1e-6,
         )
 

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -3,114 +3,67 @@ __doc__ = """ Test Wrapper Classes used in contact in Elastica.joint implementat
 import numpy as np
 from numpy.testing import assert_allclose
 from elastica.joint import ExternalContact, SelfContact
+from elastica.typing import RodBase, RigidBodyBase
 
 
 def mock_rod_init(self):
 
     "Initializing Rod"
+    "Details of initialization are given in test_contact_specific_functions.py"
 
     self.n_elems = 2
-    self.position_collection = np.array(
-        [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15]]
-    )
-    self.radius = np.array([5.12952263, 0.19493561, 0.72904683, 0.21676892, 0.18705351])
-    self.lengths = np.array([0.89050271, 0.7076813, 0.21078658, 0.95372826, 0.86037329])
-    self.tangents = np.array(
-        [
-            [-0.92511524, 0.19778438, 0.42897242, 0.28430662, -0.57637184],
-            [1.73622348, 1.55757074, -0.4606567, -1.30228854, -0.34647765],
-            [0.61561226, -0.86529598, -0.9180072, 0.99279484, -2.09424394],
-        ]
-    )
-
-    self.internal_forces = np.array(
-        [
-            [-0.77306421, -0.25648047, -0.93419262, -0.77665042, -0.33345937],
-            [-1.04834225, -1.92250527, -1.46505411, -0.71192403, -0.99256648],
-            [0.33465609, 1.22871475, 0.06250578, -0.49531749, 0.58044695],
-        ]
-    )
-
-    self.external_forces = np.array(
-        [
-            [-0.77306421, -0.25648047, -0.93419262, -0.77665042, -0.33345937],
-            [-1.04834225, -1.92250527, -1.46505411, -0.71192403, -0.99256648],
-            [0.33465609, 1.22871475, 0.06250578, -0.49531749, 0.58044695],
-        ]
-    )
-
-    self.velocity_collection = np.array(
-        [
-            [0.70544082, 0.05240655, -1.93283144, -0.35381074, -0.1305802],
-            [-0.15193337, -0.16199143, 0.94085659, 0.53076711, 2.15766298],
-            [-0.60888955, 0.36362709, 1.31370542, -0.7457939, -0.78005834],
-        ]
-    )
+    self.position_collection = np.array([[1, 2], [0, 0], [0, 0]])
+    self.radius = np.array([1, 1])
+    self.lengths = np.array([0.5, 0.5])
+    self.tangents = np.array([[1.0, 1.0], [0.0, 0.0], [0.0, 0.0]])
+    self.internal_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    self.external_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    self.velocity_collection = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
 
 
 def mock_rigid_body_init(self):
 
     "Initializing Rigid Body"
+    "Details of initialization are given in test_contact_specific_functions.py"
 
-    self.position_collection = np.array([[4], [5], [6]])
-    self.director_collection = np.array(
-        [[[1], [0], [0]], [[0], [0.707], [-0.707]], [[0], [0.707], [0.707]]]
-    )
-    self.radius = np.array([1.5])
-    self.length = np.array([5.0])
     self.n_elems = 1
-    self.external_forces = np.array([[-0.27817918], [-0.04400299], [1.36401515]])
-    self.external_torques = np.array([[-0.2338623], [-1.39748107], [0.31085926]])
-    self.velocity_collection = np.array(
-        [
-            [0.63276313, -0.32444142, 0.61402734],
-            [-0.01528792, -0.28025795, 0.32799382],
-            [-2.22331567, -0.80881859, -0.82109278],
-        ]
+    self.position_collection = np.array([[0], [0], [0]])
+    self.director_collection = np.array(
+        [[[1.0], [0.0], [0.0]], [[0.0], [0.0], [1.0]], [[0.0], [0.0], [1.0]]]
     )
+    self.radius = np.array([1.0])
+    self.length = np.array([2.0])
+    self.external_forces = np.array([[0.0], [0.0], [0.0]])
+    self.external_torques = np.array([[0.0], [0.0], [0.0]])
+    self.velocity_collection = np.array([[0.0], [0.0], [0.0]])
 
 
-MockRod = type("MockRod", (object,), {"__init__": mock_rod_init})
+MockRod = type("MockRod", (RodBase,), {"__init__": mock_rod_init})
 
-MockRigidBody = type("MockRigidBody", (object,), {"__init__": mock_rigid_body_init})
+MockRigidBody = type(
+    "MockRigidBody", (RigidBodyBase,), {"__init__": mock_rigid_body_init}
+)
 
 
 def test_external_contact_rod_rigid_body_with_collision():
 
     "Testing External Contact wrapper with Collision with analytical verified values"
 
-    tol = 1e-6
     mock_rod = MockRod()
     mock_rigid_body = MockRigidBody()
-    ext_contact = ExternalContact(k=1.0, nu=0.5)
+    ext_contact = ExternalContact(k=1.0, nu=0.0)
     ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
 
+    """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
     assert_allclose(
         mock_rod.external_forces,
-        np.array(
-            [
-                [-0.992182, -0.694716, -0.934193, -0.77665, -0.333459],
-                [-1.071788, -1.969396, -1.465054, -0.711924, -0.992566],
-                [0.661799, 1.883001, 0.062506, -0.495317, 0.580447],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        np.array([[0.16, 0.33], [0.0, 0.0], [0.0, 0.0]]),
+        atol=1e-2,
     )
 
-    assert_allclose(
-        mock_rigid_body.external_forces,
-        np.array([[0.379174], [0.026334], [0.382586]]),
-        rtol=tol,
-        atol=tol,
-    )
+    assert_allclose(mock_rigid_body.external_forces, np.array([[-0.5], [0.0], [0.0]]))
 
-    assert_allclose(
-        mock_rigid_body.external_torques,
-        np.array([[-2.092858], [0.245406], [0.310859]]),
-        rtol=tol,
-        atol=tol,
-    )
+    assert_allclose(mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]))
 
 
 def test_external_contact_rod_rigid_body_without_collision():
@@ -120,6 +73,8 @@ def test_external_contact_rod_rigid_body_without_collision():
     mock_rod = MockRod()
     mock_rigid_body = MockRigidBody()
     ext_contact = ExternalContact(k=1.0, nu=0.5)
+
+    """Setting rigid body position such that there is no collision"""
     mock_rigid_body.position_collection = np.array([[400], [500], [600]])
     mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
     mock_rigid_body_external_forces_before_execution = (
@@ -144,40 +99,23 @@ def test_external_contact_rod_rigid_body_without_collision():
 def test_external_contact_with_two_rods_with_collision():
 
     "Testing External Contact wrapper with two rods with analytical verified values"
+    "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_rod_rod()'"
 
-    tol = 1e-6
     mock_rod_one = MockRod()
     mock_rod_two = MockRod()
-    mock_rod_two.position_collection = np.array(
-        [[1.2, 2.2, 3.2, 4.2, 5.2], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15]]
-    )
-    ext_contact = ExternalContact(k=1.0, nu=0.5)
+    mock_rod_two.position_collection = np.array([[2.5, 3.5], [0, 0], [0, 0]])
+    ext_contact = ExternalContact(k=1.0, nu=0.0)
     ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
 
     assert_allclose(
         mock_rod_one.external_forces,
-        np.array(
-            [
-                [-5.848848, -7.696102, 2.569813, 0.257867, -0.091002],
-                [-3.177381, -2.169013, 2.890443, -0.240067, -0.864637],
-                [-1.309157, 4.732951, 7.427895, 0.333335, 0.835572],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        np.array([[-0.33, -0.66], [0, 0], [0, 0]]),
+        atol=1e-2,
     )
-
     assert_allclose(
         mock_rod_two.external_forces,
-        np.array(
-            [
-                [-6.167549, -1.298545, 10.66082, 1.435384, 0.030468],
-                [-2.17321, -4.425968, -1.173107, -0.060764, -0.887081],
-                [-4.672525, -7.453212, 2.279982, 0.528223, 0.718947],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        np.array([[0.33, 0.66], [0, 0], [0, 0]]),
+        atol=1e-2,
     )
 
 
@@ -185,33 +123,21 @@ def test_external_contact_with_two_rods_without_collision():
 
     "Testing External Contact wrapper with two rods with analytical verified values"
 
-    tol = 1e-6
     mock_rod_one = MockRod()
     mock_rod_two = MockRod()
-    mock_rod_two.position_collection = np.array(
-        [
-            [100, 200, 300, 400, 500],
-            [600, 700, 800, 900, 100],
-            [110, 120, 130, 140, 150],
-        ]
-    )
-    ext_contact = ExternalContact(k=1.0, nu=0.5)
+
+    "Setting rod two position such that there is no collision"
+    mock_rod_two.position_collection = np.array([[100, 200], [600, 700], [110, 120]])
+    ext_contact = ExternalContact(k=1.0, nu=0.0)
     mock_rod_one_external_forces_before_execution = mock_rod_one.external_forces.copy()
     mock_rod_two_external_forces_before_execution = mock_rod_two.external_forces.copy()
     ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
 
     assert_allclose(
-        mock_rod_one.external_forces,
-        mock_rod_one_external_forces_before_execution,
-        rtol=tol,
-        atol=tol,
+        mock_rod_one.external_forces, mock_rod_one_external_forces_before_execution
     )
-
     assert_allclose(
-        mock_rod_two.external_forces,
-        mock_rod_two_external_forces_before_execution,
-        rtol=tol,
-        atol=tol,
+        mock_rod_two.external_forces, mock_rod_two_external_forces_before_execution
     )
 
 
@@ -219,22 +145,32 @@ def test_self_contact_with_rod_self_collision():
 
     "Testing Self Contact wrapper rod self collision with analytical verified values"
 
-    tol = 1e-6
     mock_rod = MockRod()
-    sel_contact = SelfContact(k=1.0, nu=0.5)
+
+    "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_self_rod()'"
+    mock_rod.n_elems = 4
+    mock_rod.position_collection = np.array([[1, 3, 5, 7], [0, 0, 0, 0], [0, 0, 0, 0]])
+    mock_rod.radius = np.array([1, 1, 1, 1])
+    mock_rod.lengths = np.array([3.0, 3.0, 3.0, 3.0])
+    mock_rod.tangents = np.array(
+        [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    )
+    mock_rod.velocity_collection = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    )
+    mock_rod.internal_forces = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    )
+    mock_rod.external_forces = np.array(
+        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    )
+    sel_contact = SelfContact(k=1.0, nu=0.0)
     sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
 
     assert_allclose(
         mock_rod.external_forces,
-        np.array(
-            [
-                [-0.976629, -0.663611, -0.934193, -0.471303, -0.028112],
-                [-1.125742, -2.077304, -1.465054, -0.595825, -0.876467],
-                [0.204132, 0.967667, 0.062506, -0.299531, 0.776233],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
+        np.array([[-0.33, -0.66, 0.5, 0.5], [0, 0, 0, 0], [0, 0, 0, 0]]),
+        atol=1e-2,
     )
 
 
@@ -242,23 +178,12 @@ def test_self_contact_with_rod_no_self_collision():
 
     "Testing Self Contact wrapper rod no self collision with analytical verified values"
 
-    tol = 1e-6
     mock_rod = MockRod()
-    mock_rod.position_collection = np.array(
-        [[1, 3, 5, 7, 9], [11, 13, 15, 17, 19], [21, 23, 25, 27, 29]]
-    )
-    sel_contact = SelfContact(k=1.0, nu=0.5)
+
+    "setting rod elements position such that tehre is no self collision"
+    mock_rod.position_collection = np.array([[1, 5], [0, 0], [0, 0]])
+    mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
+    sel_contact = SelfContact(k=1.0, nu=0.0)
     sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
 
-    assert_allclose(
-        mock_rod.external_forces,
-        np.array(
-            [
-                [-0.77306421, -0.25648047, -0.93419262, -0.77665042, -0.33345937],
-                [-1.04834225, -1.92250527, -1.46505411, -0.71192403, -0.99256648],
-                [0.33465609, 1.22871475, 0.06250578, -0.49531749, 0.58044695],
-            ]
-        ),
-        rtol=tol,
-        atol=tol,
-    )
+    assert_allclose(mock_rod.external_forces, mock_rod_external_forces_before_execution)

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -47,146 +47,216 @@ MockRigidBody = type(
 )
 
 
-def test_external_contact_rod_rigid_body_with_collision():
+class TestExternalContact:
+    def test_external_contact_rod_rigid_body_with_collision_with_k_without_nu(self):
 
-    "Testing External Contact wrapper with Collision with analytical verified values"
+        "Testing External Contact wrapper with Collision with analytical verified values"
 
-    mock_rod = MockRod()
-    mock_rigid_body = MockRigidBody()
-    ext_contact = ExternalContact(k=1.0, nu=0.0)
-    ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+        mock_rod = MockRod()
+        mock_rigid_body = MockRigidBody()
+        ext_contact = ExternalContact(k=1.0, nu=0.0)
+        ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
 
-    """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
-    assert_allclose(
-        mock_rod.external_forces,
-        np.array([[0.166666, 0.333333, 0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-        atol=1e-6,
-    )
+        """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
+        assert_allclose(
+            mock_rod.external_forces,
+            np.array([[0.166666, 0.333333, 0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            atol=1e-6,
+        )
 
-    assert_allclose(
-        mock_rigid_body.external_forces, np.array([[-0.5], [0.0], [0.0]]), atol=1e-6
-    )
+        assert_allclose(
+            mock_rigid_body.external_forces, np.array([[-0.5], [0.0], [0.0]]), atol=1e-6
+        )
 
-    assert_allclose(
-        mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
-    )
+        assert_allclose(
+            mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
+        )
+
+    def test_external_contact_rod_rigid_body_with_collision_without_k_with_nu(self):
+
+        "Testing External Contact wrapper with Collision with analytical verified values"
+
+        mock_rod = MockRod()
+        "Moving rod towards the cylinder with a velocity of -1 in x-axis"
+        mock_rod.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
+        mock_rigid_body = MockRigidBody()
+        "Moving cylinder towards the rod with a velocity of 1 in x-axis"
+        mock_rigid_body.velocity_collection = np.array([[1], [0], [0]])
+        ext_contact = ExternalContact(k=0.0, nu=1.0)
+        ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+
+        """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
+        assert_allclose(
+            mock_rod.external_forces,
+            np.array([[0.5, 1, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_forces, np.array([[-1.5], [0], [0]]), atol=1e-6
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
+        )
+
+    def test_external_contact_rod_rigid_body_without_collision(self):
+
+        "Testing External Contact wrapper without Collision with analytical verified values"
+
+        mock_rod = MockRod()
+        mock_rigid_body = MockRigidBody()
+        ext_contact = ExternalContact(k=1.0, nu=0.5)
+
+        """Setting rigid body position such that there is no collision"""
+        mock_rigid_body.position_collection = np.array([[400], [500], [600]])
+        mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
+        mock_rigid_body_external_forces_before_execution = (
+            mock_rigid_body.external_forces.copy()
+        )
+        mock_rigid_body_external_torques_before_execution = (
+            mock_rigid_body.external_torques.copy()
+        )
+        ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+
+        assert_allclose(
+            mock_rod.external_forces, mock_rod_external_forces_before_execution
+        )
+        assert_allclose(
+            mock_rigid_body.external_forces,
+            mock_rigid_body_external_forces_before_execution,
+        )
+        assert_allclose(
+            mock_rigid_body.external_torques,
+            mock_rigid_body_external_torques_before_execution,
+        )
+
+    def test_external_contact_with_two_rods_with_collision_with_k_without_nu(self):
+
+        "Testing External Contact wrapper with two rods with analytical verified values"
+        "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_rod_rod()'"
+
+        mock_rod_one = MockRod()
+        mock_rod_two = MockRod()
+        mock_rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
+        ext_contact = ExternalContact(k=1.0, nu=0.0)
+        ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
+
+        assert_allclose(
+            mock_rod_one.external_forces,
+            np.array([[0, -0.5, -0.5], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+        assert_allclose(
+            mock_rod_two.external_forces,
+            np.array([[0.333333, 0.666666, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+    def test_external_contact_with_two_rods_with_collision_without_k_with_nu(self):
+
+        "Testing External Contact wrapper with two rods with analytical verified values"
+        "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_rod_rod()'"
+
+        mock_rod_one = MockRod()
+        mock_rod_two = MockRod()
+
+        """Moving the rods towards each other with a velocity of 1 along the x-axis."""
+        mock_rod_one.velocity_collection = np.array([[1, 0, 0], [1, 0, 0], [1, 0, 0]])
+        mock_rod_two.velocity_collection = np.array(
+            [[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]]
+        )
+        mock_rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
+        ext_contact = ExternalContact(k=0.0, nu=1.0)
+        ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
+
+        assert_allclose(
+            mock_rod_one.external_forces,
+            np.array(
+                [[0, -0.25, -0.25], [0, 0, 0], [0, 0, 0]],
+            ),
+            atol=1e-6,
+        )
+        assert_allclose(
+            mock_rod_two.external_forces,
+            np.array([[0.166666, 0.333333, 0], [0, 0, 0], [0, 0, 0]]),
+            atol=1e-6,
+        )
+
+    def test_external_contact_with_two_rods_without_collision(self):
+
+        "Testing External Contact wrapper with two rods with analytical verified values"
+
+        mock_rod_one = MockRod()
+        mock_rod_two = MockRod()
+
+        "Setting rod two position such that there is no collision"
+        mock_rod_two.position_collection = np.array(
+            [[100, 101, 102], [0, 0, 0], [0, 0, 0]]
+        )
+        ext_contact = ExternalContact(k=1.0, nu=1.0)
+        mock_rod_one_external_forces_before_execution = (
+            mock_rod_one.external_forces.copy()
+        )
+        mock_rod_two_external_forces_before_execution = (
+            mock_rod_two.external_forces.copy()
+        )
+        ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
+
+        assert_allclose(
+            mock_rod_one.external_forces, mock_rod_one_external_forces_before_execution
+        )
+        assert_allclose(
+            mock_rod_two.external_forces, mock_rod_two_external_forces_before_execution
+        )
 
 
-def test_external_contact_rod_rigid_body_without_collision():
+class TestSelfContact:
+    def test_self_contact_with_rod_self_collision(self):
 
-    "Testing External Contact wrapper without Collision with analytical verified values"
+        "Testing Self Contact wrapper rod self collision with analytical verified values"
 
-    mock_rod = MockRod()
-    mock_rigid_body = MockRigidBody()
-    ext_contact = ExternalContact(k=1.0, nu=0.5)
+        mock_rod = MockRod()
 
-    """Setting rigid body position such that there is no collision"""
-    mock_rigid_body.position_collection = np.array([[400], [500], [600]])
-    mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
-    mock_rigid_body_external_forces_before_execution = (
-        mock_rigid_body.external_forces.copy()
-    )
-    mock_rigid_body_external_torques_before_execution = (
-        mock_rigid_body.external_torques.copy()
-    )
-    ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+        "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_self_rod()'"
+        mock_rod.n_elems = 3
+        mock_rod.position_collection = np.array(
+            [[1, 4, 4, 1], [0, 0, 1, 1], [0, 0, 0, 0]]
+        )
+        mock_rod.radius = np.array([1, 1, 1])
+        mock_rod.lengths = np.array([3, 3, 3])
+        mock_rod.tangents = np.array(
+            [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        )
+        mock_rod.velocity_collection = np.array(
+            [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+        )
+        mock_rod.internal_forces = np.array(
+            [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+        )
+        mock_rod.external_forces = np.array(
+            [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+        )
+        sel_contact = SelfContact(k=1.0, nu=0.0)
+        sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
 
-    assert_allclose(mock_rod.external_forces, mock_rod_external_forces_before_execution)
-    assert_allclose(
-        mock_rigid_body.external_forces,
-        mock_rigid_body_external_forces_before_execution,
-    )
-    assert_allclose(
-        mock_rigid_body.external_torques,
-        mock_rigid_body_external_torques_before_execution,
-    )
+        assert_allclose(
+            mock_rod.external_forces,
+            np.array([[0, 0, 0, 0], [-0.333333, -0.666666, 0.5, 0.5], [0, 0, 0, 0]]),
+            atol=1e-6,
+        )
 
+    def test_self_contact_with_rod_no_self_collision(self):
 
-def test_external_contact_with_two_rods_with_collision():
+        "Testing Self Contact wrapper rod no self collision with analytical verified values"
 
-    "Testing External Contact wrapper with two rods with analytical verified values"
-    "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_rod_rod()'"
+        mock_rod = MockRod()
 
-    mock_rod_one = MockRod()
-    mock_rod_two = MockRod()
-    mock_rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
-    ext_contact = ExternalContact(k=1.0, nu=0.0)
-    ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
+        "the initially set rod does not have self collision"
+        mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
+        sel_contact = SelfContact(k=1.0, nu=1.0)
+        sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
 
-    assert_allclose(
-        mock_rod_one.external_forces,
-        np.array([[0, -0.5, -0.5], [0, 0, 0], [0, 0, 0]]),
-        atol=1e-6,
-    )
-    assert_allclose(
-        mock_rod_two.external_forces,
-        np.array([[0.333333, 0.666666, 0], [0, 0, 0], [0, 0, 0]]),
-        atol=1e-6,
-    )
-
-
-def test_external_contact_with_two_rods_without_collision():
-
-    "Testing External Contact wrapper with two rods with analytical verified values"
-
-    mock_rod_one = MockRod()
-    mock_rod_two = MockRod()
-
-    "Setting rod two position such that there is no collision"
-    mock_rod_two.position_collection = np.array([[100, 101, 102], [0, 0, 0], [0, 0, 0]])
-    ext_contact = ExternalContact(k=1.0, nu=1.0)
-    mock_rod_one_external_forces_before_execution = mock_rod_one.external_forces.copy()
-    mock_rod_two_external_forces_before_execution = mock_rod_two.external_forces.copy()
-    ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
-
-    assert_allclose(
-        mock_rod_one.external_forces, mock_rod_one_external_forces_before_execution
-    )
-    assert_allclose(
-        mock_rod_two.external_forces, mock_rod_two_external_forces_before_execution
-    )
-
-
-def test_self_contact_with_rod_self_collision():
-
-    "Testing Self Contact wrapper rod self collision with analytical verified values"
-
-    mock_rod = MockRod()
-
-    "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_self_rod()'"
-    mock_rod.n_elems = 3
-    mock_rod.position_collection = np.array([[1, 4, 4, 1], [0, 0, 1, 1], [0, 0, 0, 0]])
-    mock_rod.radius = np.array([1, 1, 1])
-    mock_rod.lengths = np.array([3, 3, 3])
-    mock_rod.tangents = np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
-    mock_rod.velocity_collection = np.array(
-        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
-    )
-    mock_rod.internal_forces = np.array(
-        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
-    )
-    mock_rod.external_forces = np.array(
-        [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
-    )
-    sel_contact = SelfContact(k=1.0, nu=0.0)
-    sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
-
-    assert_allclose(
-        mock_rod.external_forces,
-        np.array([[0, 0, 0, 0], [-0.333333, -0.666666, 0.5, 0.5], [0, 0, 0, 0]]),
-        atol=1e-6,
-    )
-
-
-def test_self_contact_with_rod_no_self_collision():
-
-    "Testing Self Contact wrapper rod no self collision with analytical verified values"
-
-    mock_rod = MockRod()
-
-    "the initially set rod does not have self collision"
-    mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
-    sel_contact = SelfContact(k=1.0, nu=1.0)
-    sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
-
-    assert_allclose(mock_rod.external_forces, mock_rod_external_forces_before_execution)
+        assert_allclose(
+            mock_rod.external_forces, mock_rod_external_forces_before_execution
+        )

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -144,7 +144,7 @@ class TestExternalContact:
 
         assert_allclose(
             mock_rod_one.external_forces,
-            np.array([[0, -0.5, -0.5], [0, 0, 0], [0, 0, 0]]),
+            np.array([[0, -0.666666, -0.333333], [0, 0, 0], [0, 0, 0]]),
             atol=1e-6,
         )
         assert_allclose(
@@ -173,7 +173,7 @@ class TestExternalContact:
         assert_allclose(
             mock_rod_one.external_forces,
             np.array(
-                [[0, -0.25, -0.25], [0, 0, 0], [0, 0, 0]],
+                [[0, -0.333333, -0.166666], [0, 0, 0], [0, 0, 0]],
             ),
             atol=1e-6,
         )
@@ -224,9 +224,9 @@ class TestSelfContact:
             [[1, 4, 4, 1], [0, 0, 1, 1], [0, 0, 0, 0]]
         )
         mock_rod.radius = np.array([1, 1, 1])
-        mock_rod.lengths = np.array([3, 3, 3])
+        mock_rod.lengths = np.array([3, 1, 3])
         mock_rod.tangents = np.array(
-            [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+            [[1.0, 0.0, -1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
         )
         mock_rod.velocity_collection = np.array(
             [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
@@ -242,7 +242,9 @@ class TestSelfContact:
 
         assert_allclose(
             mock_rod.external_forces,
-            np.array([[0, 0, 0, 0], [-0.333333, -0.666666, 0.5, 0.5], [0, 0, 0, 0]]),
+            np.array(
+                [[0, 0, 0, 0], [-0.333333, -0.666666, 0.666666, 0.333333], [0, 0, 0, 0]]
+            ),
             atol=1e-6,
         )
 

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -12,13 +12,15 @@ def mock_rod_init(self):
     "Details of initialization are given in test_contact_specific_functions.py"
 
     self.n_elems = 2
-    self.position_collection = np.array([[1, 2], [0, 0], [0, 0]])
+    self.position_collection = np.array([[1, 2, 3], [0, 0, 0], [0, 0, 0]])
     self.radius = np.array([1, 1])
-    self.lengths = np.array([0.5, 0.5])
+    self.lengths = np.array([1, 1])
     self.tangents = np.array([[1.0, 1.0], [0.0, 0.0], [0.0, 0.0]])
-    self.internal_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
-    self.external_forces = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
-    self.velocity_collection = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    self.internal_forces = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    self.external_forces = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    self.velocity_collection = np.array(
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    )
 
 
 def mock_rigid_body_init(self):
@@ -29,7 +31,7 @@ def mock_rigid_body_init(self):
     self.n_elems = 1
     self.position_collection = np.array([[0], [0], [0]])
     self.director_collection = np.array(
-        [[[1.0], [0.0], [0.0]], [[0.0], [0.0], [1.0]], [[0.0], [0.0], [1.0]]]
+        [[[1.0], [0.0], [0.0]], [[0.0], [1.0], [0.0]], [[0.0], [0.0], [1.0]]]
     )
     self.radius = np.array([1.0])
     self.length = np.array([2.0])
@@ -57,13 +59,17 @@ def test_external_contact_rod_rigid_body_with_collision():
     """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
     assert_allclose(
         mock_rod.external_forces,
-        np.array([[0.16, 0.33], [0.0, 0.0], [0.0, 0.0]]),
-        atol=1e-2,
+        np.array([[0.166666, 0.333333, 0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+        atol=1e-6,
     )
 
-    assert_allclose(mock_rigid_body.external_forces, np.array([[-0.5], [0.0], [0.0]]))
+    assert_allclose(
+        mock_rigid_body.external_forces, np.array([[-0.5], [0.0], [0.0]]), atol=1e-6
+    )
 
-    assert_allclose(mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]))
+    assert_allclose(
+        mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
+    )
 
 
 def test_external_contact_rod_rigid_body_without_collision():
@@ -103,19 +109,19 @@ def test_external_contact_with_two_rods_with_collision():
 
     mock_rod_one = MockRod()
     mock_rod_two = MockRod()
-    mock_rod_two.position_collection = np.array([[2.5, 3.5], [0, 0], [0, 0]])
+    mock_rod_two.position_collection = np.array([[4, 5, 6], [0, 0, 0], [0, 0, 0]])
     ext_contact = ExternalContact(k=1.0, nu=0.0)
     ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
 
     assert_allclose(
         mock_rod_one.external_forces,
-        np.array([[-0.33, -0.66], [0, 0], [0, 0]]),
-        atol=1e-2,
+        np.array([[0, -0.5, -0.5], [0, 0, 0], [0, 0, 0]]),
+        atol=1e-6,
     )
     assert_allclose(
         mock_rod_two.external_forces,
-        np.array([[0.33, 0.66], [0, 0], [0, 0]]),
-        atol=1e-2,
+        np.array([[0.333333, 0.666666, 0], [0, 0, 0], [0, 0, 0]]),
+        atol=1e-6,
     )
 
 
@@ -127,8 +133,8 @@ def test_external_contact_with_two_rods_without_collision():
     mock_rod_two = MockRod()
 
     "Setting rod two position such that there is no collision"
-    mock_rod_two.position_collection = np.array([[100, 200], [600, 700], [110, 120]])
-    ext_contact = ExternalContact(k=1.0, nu=0.0)
+    mock_rod_two.position_collection = np.array([[100, 101, 102], [0, 0, 0], [0, 0, 0]])
+    ext_contact = ExternalContact(k=1.0, nu=1.0)
     mock_rod_one_external_forces_before_execution = mock_rod_one.external_forces.copy()
     mock_rod_two_external_forces_before_execution = mock_rod_two.external_forces.copy()
     ext_contact.apply_forces(mock_rod_one, 0, mock_rod_two, 0)
@@ -148,13 +154,11 @@ def test_self_contact_with_rod_self_collision():
     mock_rod = MockRod()
 
     "Test values have been copied from 'test_contact_specific_functions.py/test_calculate_contact_forces_self_rod()'"
-    mock_rod.n_elems = 4
-    mock_rod.position_collection = np.array([[1, 3, 5, 7], [0, 0, 0, 0], [0, 0, 0, 0]])
-    mock_rod.radius = np.array([1, 1, 1, 1])
-    mock_rod.lengths = np.array([3.0, 3.0, 3.0, 3.0])
-    mock_rod.tangents = np.array(
-        [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
-    )
+    mock_rod.n_elems = 3
+    mock_rod.position_collection = np.array([[1, 4, 4, 1], [0, 0, 1, 1], [0, 0, 0, 0]])
+    mock_rod.radius = np.array([1, 1, 1])
+    mock_rod.lengths = np.array([3, 3, 3])
+    mock_rod.tangents = np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
     mock_rod.velocity_collection = np.array(
         [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
     )
@@ -169,8 +173,8 @@ def test_self_contact_with_rod_self_collision():
 
     assert_allclose(
         mock_rod.external_forces,
-        np.array([[-0.33, -0.66, 0.5, 0.5], [0, 0, 0, 0], [0, 0, 0, 0]]),
-        atol=1e-2,
+        np.array([[0, 0, 0, 0], [-0.333333, -0.666666, 0.5, 0.5], [0, 0, 0, 0]]),
+        atol=1e-6,
     )
 
 
@@ -180,10 +184,9 @@ def test_self_contact_with_rod_no_self_collision():
 
     mock_rod = MockRod()
 
-    "setting rod elements position such that tehre is no self collision"
-    mock_rod.position_collection = np.array([[1, 5], [0, 0], [0, 0]])
+    "the initially set rod does not have self collision"
     mock_rod_external_forces_before_execution = mock_rod.external_forces.copy()
-    sel_contact = SelfContact(k=1.0, nu=0.0)
+    sel_contact = SelfContact(k=1.0, nu=1.0)
     sel_contact.apply_forces(mock_rod, 0, mock_rod, 0)
 
     assert_allclose(mock_rod.external_forces, mock_rod_external_forces_before_execution)

--- a/tests/test_contact_wrapper_classes.py
+++ b/tests/test_contact_wrapper_classes.py
@@ -48,7 +48,9 @@ MockRigidBody = type(
 
 
 class TestExternalContact:
-    def test_external_contact_rod_rigid_body_with_collision_with_k_without_nu(self):
+    def test_external_contact_rod_rigid_body_with_collision_with_k_without_nu_and_friction(
+        self,
+    ):
 
         "Testing External Contact wrapper with Collision with analytical verified values"
 
@@ -72,7 +74,9 @@ class TestExternalContact:
             mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
         )
 
-    def test_external_contact_rod_rigid_body_with_collision_without_k_with_nu(self):
+    def test_external_contact_rod_rigid_body_with_collision_with_nu_without_k_and_friction(
+        self,
+    ):
 
         "Testing External Contact wrapper with Collision with analytical verified values"
 
@@ -100,7 +104,9 @@ class TestExternalContact:
             mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
         )
 
-    def test_external_contact_rod_rigid_body_with_collision_with_k_and_nu(self):
+    def test_external_contact_rod_rigid_body_with_collision_with_k_and_nu_without_friction(
+        self,
+    ):
 
         "Testing External Contact wrapper with Collision with analytical verified values"
 
@@ -122,6 +128,44 @@ class TestExternalContact:
 
         assert_allclose(
             mock_rigid_body.external_forces, np.array([[-2], [0], [0]]), atol=1e-6
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_torques, np.array([[0.0], [0.0], [0.0]]), atol=1e-6
+        )
+
+    def test_external_contact_rod_rigid_body_with_collision_with_k_and_nu_and_friction(
+        self,
+    ):
+
+        "Testing External Contact wrapper with Collision with analytical verified values"
+
+        mock_rod = MockRod()
+        "Moving rod towards the cylinder with a velocity of -1 in x-axis"
+        mock_rod.velocity_collection = np.array([[-1, 0, 0], [-1, 0, 0], [-1, 0, 0]])
+        mock_rigid_body = MockRigidBody()
+        "Moving cylinder towards the rod with a velocity of 1 in x-axis"
+        mock_rigid_body.velocity_collection = np.array([[1], [0], [0]])
+        ext_contact = ExternalContact(
+            k=1.0, nu=1.0, velocity_damping_coefficient=0.1, friction_coefficient=0.1
+        )
+        ext_contact.apply_forces(mock_rod, 0, mock_rigid_body, 1)
+
+        """Details and reasoning about the values are given in 'test_contact_specific_functions.py/test_claculate_contact_forces_rod_rigid_body()'"""
+        assert_allclose(
+            mock_rod.external_forces,
+            np.array(
+                [
+                    [0.666666, 1.333333, 0],
+                    [0.033333, 0.066666, 0],
+                    [0.033333, 0.066666, 0],
+                ]
+            ),
+            atol=1e-6,
+        )
+
+        assert_allclose(
+            mock_rigid_body.external_forces, np.array([[-2], [-0.1], [-0.1]]), atol=1e-6
         )
 
         assert_allclose(


### PR DESCRIPTION
This PR aims to solve issue #271.

The following changes were made:

1. Overall changes: 
- all pytests were reworked and input and expected values were handcrafted.
- added calculations and verification methods as comments

2. File-specific changes
- tests_contact_common_functions:
         - corrected names of variables
         - for the '_find_min_dist' test, arbitrary close lines and away lines were combined into a single test and test case for 
           parallel lines were added
         - point to be noted: find min dist function returns -1 for contact point of system 1 if the lines intersect
- test_contact_specific_functions:
         - Common rod and cylinder were initialized for tests.
         - test only assess the working of function with contact forces and many initial conditions were added (ex: stationary 
           systems and zero initial forces) for easier calculations.
- test_wrapper_classes:
         - correct initialization of rod and rigidbody.
         - test values were copied from specific function pytests.

If the tests are acceptable, we can make more tests that are not 'nu' independent.

Also, can we remove the elif block at https://github.com/GazzolaLab/PyElastica/blob/master/elastica/joint.py/#L574, I think this code is redundant as 'i' never equals 'n_points'.