### PR TITLE
Surface subclass: plane, and tests

### DIFF
--- a/elastica/surface/__init__.py
+++ b/elastica/surface/__init__.py
@@ -1,2 +1,3 @@
 __doc__ = """Surface classes"""
 from elastica.surface.surface_base import SurfaceBase
+from elastica.surface.plane import Plane

--- a/elastica/surface/plane.py
+++ b/elastica/surface/plane.py
@@ -7,7 +7,7 @@ from elastica.utils import Tolerance
 
 
 class Plane(SurfaceBase):
-    def __init__(self, plane_origin, plane_normal):
+    def __init__(self, plane_origin: np.ndarray, plane_normal: np.ndarray):
         """
         Plane surface initializer.
 
@@ -29,4 +29,3 @@ class Plane(SurfaceBase):
         )
         self.normal = plane_normal.reshape(3)
         self.origin = plane_origin.reshape(3, 1)
-        self.tol = 1e-4

--- a/elastica/surface/plane.py
+++ b/elastica/surface/plane.py
@@ -27,5 +27,5 @@ class Plane(SurfaceBase):
             atol=Tolerance.atol(),
             err_msg="plane normal is not a unit vector",
         )
-        self.normal = plane_normal.reshape(3)
+        self.normal = np.asarray(plane_normal).reshape(3)
         self.origin = plane_origin.reshape(3, 1)

--- a/elastica/surface/plane.py
+++ b/elastica/surface/plane.py
@@ -13,12 +13,12 @@ class Plane(SurfaceBase):
 
         Parameters
         ----------
-        plane_origin: numpy.ndarray
-        2D (dim, 1) array containing data with 'float' type.
-        Origin of the plane.
-        plane_normal: numpy.ndarray
-        2D (dim, 1) array containing data with 'float' type.
-        The normal vector of the plane, must be normalized.
+        plane_origin: np.ndarray
+            Origin of the plane.
+            Expect (3,1)-shaped array.
+        plane_normal: np.ndarray
+            The normal vector of the plane, must be normalized.
+            Expect (3,1)-shaped array.
         """
 
         assert_allclose(

--- a/elastica/surface/plane.py
+++ b/elastica/surface/plane.py
@@ -1,0 +1,32 @@
+__doc__ = """plane surface class"""
+
+from elastica.surface.surface_base import SurfaceBase
+import numpy as np
+from numpy.testing import assert_allclose
+from elastica.utils import Tolerance
+
+
+class Plane(SurfaceBase):
+    def __init__(self, plane_origin, plane_normal):
+        """
+        Plane surface initializer.
+
+        Parameters
+        ----------
+        plane_origin: numpy.ndarray
+        2D (dim, 1) array containing data with 'float' type.
+        Origin of the plane.
+        plane_normal: numpy.ndarray
+        2D (dim, 1) array containing data with 'float' type.
+        The normal vector of the plane, must be normalized.
+        """
+
+        assert_allclose(
+            np.linalg.norm(plane_normal),
+            1,
+            atol=Tolerance.atol(),
+            err_msg="plane normal is not a unit vector",
+        )
+        self.normal = plane_normal.reshape(3)
+        self.origin = plane_origin.reshape(3, 1)
+        self.tol = 1e-4

--- a/elastica/surface/plane.py
+++ b/elastica/surface/plane.py
@@ -28,4 +28,4 @@ class Plane(SurfaceBase):
             err_msg="plane normal is not a unit vector",
         )
         self.normal = np.asarray(plane_normal).reshape(3)
-        self.origin = plane_origin.reshape(3, 1)
+        self.origin = np.asarray(plane_origin).reshape(3, 1)

--- a/tests/test_surface/test_plane.py
+++ b/tests/test_surface/test_plane.py
@@ -39,5 +39,3 @@ def test_plane_initialization():
     with pytest.raises(AssertionError) as excinfo:
         test_plane = Plane(plane_origin, invalid_plane_normal)
     assert "plane normal is not a unit vector" in str(excinfo.value)
-
-

--- a/tests/test_surface/test_plane.py
+++ b/tests/test_surface/test_plane.py
@@ -41,7 +41,3 @@ def test_plane_initialization():
     assert "plane normal is not a unit vector" in str(excinfo.value)
 
 
-if __name__ == "__main__":
-    from pytest import main
-
-    main([__file__])

--- a/tests/test_surface/test_plane.py
+++ b/tests/test_surface/test_plane.py
@@ -1,0 +1,38 @@
+__doc__ = """Tests for plane surface class"""
+import numpy as np
+from numpy.testing import assert_allclose
+from elastica.utils import Tolerance
+from elastica.surface import Plane
+
+
+# tests Initialisation of plane
+def test_plane_initialization():
+    """
+    This test case is for testing initialization of rigid sphere and it checks the
+    validity of the members of sphere class.
+
+    Returns
+    -------
+
+    """
+    # setting up test params
+    plane_origin = np.random.rand(3).reshape(3, 1)
+    plane_normal_direction = np.random.rand(3).reshape(3)
+    plane_normal = plane_normal_direction / np.linalg.norm(plane_normal_direction)
+
+    test_plane = Plane(plane_origin, plane_normal)
+    # checking plane origin
+    assert_allclose(
+        test_plane.origin,
+        plane_origin,
+        atol=Tolerance.atol(),
+    )
+
+    # checking plane normal
+    assert_allclose(test_plane.normal, plane_normal, atol=Tolerance.atol())
+
+
+if __name__ == "__main__":
+    from pytest import main
+
+    main([__file__])

--- a/tests/test_surface/test_plane.py
+++ b/tests/test_surface/test_plane.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from elastica.utils import Tolerance
 from elastica.surface import Plane
+import pytest
 
 
 # tests Initialisation of plane
@@ -30,6 +31,14 @@ def test_plane_initialization():
 
     # checking plane normal
     assert_allclose(test_plane.normal, plane_normal, atol=Tolerance.atol())
+
+    # check unnormalized error message
+    invalid_plane_normal = np.zeros(
+        3,
+    )
+    with pytest.raises(AssertionError) as excinfo:
+        test_plane = Plane(plane_origin, invalid_plane_normal)
+    assert "plane normal is not a unit vector" in str(excinfo.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Third contact module PR mentioned in [Issue](https://github.com/GazzolaLab/PyElastica/issues/113) 

This PR includes:
- New plane surface subclass, will be used to define rod-plane and cylinder-plane contact classes that will replace `InteractionPlane`, `AnistropicFrictionalPlane` and `InteractionPlaneRigidBody` in interaction.
- Plane object initialization test.
