### PR TITLE
Memory block refactor

### DIFF
--- a/elastica/memory_block/memory_block_rigid_body.py
+++ b/elastica/memory_block/memory_block_rigid_body.py
@@ -7,7 +7,7 @@ from elastica.rigidbody.data_structures import _RigidRodSymplecticStepperMixin
 
 
 class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
-    def __init__(self, systems: Sequence, system_idx_list: List[int]):
+    def __init__(self, systems: Sequence, system_idx_list: Sequence[np.int64]):
 
         self.n_bodies = len(systems)
         self.n_elems = self.n_bodies
@@ -117,7 +117,7 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
 
         Parameters
         ----------
-        system
+        systems
 
         Returns
         -------

--- a/elastica/memory_block/memory_block_rigid_body.py
+++ b/elastica/memory_block/memory_block_rigid_body.py
@@ -1,6 +1,6 @@
 __doc__ = """Create block-structure class for collection of rigid body systems."""
 import numpy as np
-from typing import Sequence, List
+from typing import Sequence, Literal
 
 from elastica.rigidbody import RigidBodyBase
 from elastica.rigidbody.data_structures import _RigidRodSymplecticStepperMixin
@@ -15,15 +15,15 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
         self.system_idx_list = np.array(system_idx_list, dtype=np.int64)
 
         # Allocate block structure using system collection.
-        self.allocate_block_variables_scalars(systems)
-        self.allocate_block_variables_vectors(systems)
-        self.allocate_block_variables_matrix(systems)
-        self.allocate_block_variables_for_symplectic_stepper(systems)
+        self._allocate_block_variables_scalars(systems)
+        self._allocate_block_variables_vectors(systems)
+        self._allocate_block_variables_matrix(systems)
+        self._allocate_block_variables_for_symplectic_stepper(systems)
 
         # Initialize the mixin class for symplectic time-stepper.
         _RigidRodSymplecticStepperMixin.__init__(self)
 
-    def allocate_block_variables_scalars(self, systems: Sequence):
+    def _allocate_block_variables_scalars(self, systems: Sequence):
         """
         This function takes system collection and allocates the variables for
         block-structure and references allocated variables back to the systems.
@@ -55,19 +55,14 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
             (len(map_scalar_dofs_in_rigid_bodies), self.n_elems)
         )
 
-        for k, v in map_scalar_dofs_in_rigid_bodies.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.scalar_dofs_in_rigid_bodies[v], (self.n_elems,)
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_scalar_dofs_in_rigid_bodies,
+            systems=systems,
+            block_memory=self.scalar_dofs_in_rigid_bodies,
+            value_type="scalar",
+        )
 
-        for k, v in map_scalar_dofs_in_rigid_bodies.items():
-            for system_idx, system in enumerate(systems):
-                self.__dict__[k][..., system_idx : system_idx + 1] = system.__dict__[k]
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., system_idx : system_idx + 1]
-                )
-
-    def allocate_block_variables_vectors(self, systems: Sequence):
+    def _allocate_block_variables_vectors(self, systems: Sequence):
         """
         This function takes system collection and allocates the vector variables for
         block-structure and references allocated vector variables back to the systems.
@@ -96,21 +91,14 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
             (len(map_vector_dofs_in_rigid_bodies), 3 * self.n_elems)
         )
 
-        for k, v in map_vector_dofs_in_rigid_bodies.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.vector_dofs_in_rigid_bodies[v], (3, self.n_elems)
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_vector_dofs_in_rigid_bodies,
+            systems=systems,
+            block_memory=self.vector_dofs_in_rigid_bodies,
+            value_type="vector",
+        )
 
-        for k, v in map_vector_dofs_in_rigid_bodies.items():
-            for system_idx, system in enumerate(systems):
-                self.__dict__[k][..., system_idx : system_idx + 1] = system.__dict__[
-                    k
-                ].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., system_idx : system_idx + 1]
-                )
-
-    def allocate_block_variables_matrix(self, systems: Sequence):
+    def _allocate_block_variables_matrix(self, systems: Sequence):
         """
         This function takes system collection and allocates the matrix variables for
         block-structure and references allocated matrix variables back to the systems.
@@ -139,21 +127,14 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
             (len(map_matrix_dofs_in_rigid_bodies), 9 * self.n_elems)
         )
 
-        for k, v in map_matrix_dofs_in_rigid_bodies.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.matrix_dofs_in_rigid_bodies[v], (3, 3, self.n_elems)
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_matrix_dofs_in_rigid_bodies,
+            systems=systems,
+            block_memory=self.matrix_dofs_in_rigid_bodies,
+            value_type="tensor",
+        )
 
-        for k, v in map_matrix_dofs_in_rigid_bodies.items():
-            for system_idx, system in enumerate(systems):
-                self.__dict__[k][..., system_idx : system_idx + 1] = system.__dict__[
-                    k
-                ].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., system_idx : system_idx + 1]
-                )
-
-    def allocate_block_variables_for_symplectic_stepper(self, systems: Sequence):
+    def _allocate_block_variables_for_symplectic_stepper(self, systems: Sequence):
         """
         This function takes system collection and allocates the variables used by symplectic
         stepper for block-structure and references allocated variables back to the systems.
@@ -181,11 +162,12 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
             "alpha_collection": 3,
         }
         self.rate_collection = np.zeros((len(map_rate_collection), 3 * self.n_elems))
-        for k, v in map_rate_collection.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.rate_collection[v], (3, self.n_elems)
-            )
-
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_rate_collection,
+            systems=systems,
+            block_memory=self.rate_collection,
+            value_type="vector",
+        )
         # For Dynamic state update of position Verlet create references
         self.v_w_collection = np.lib.stride_tricks.as_strided(
             self.rate_collection[0:2], (2, 3 * self.n_elems)
@@ -195,11 +177,55 @@ class MemoryBlockRigidBody(RigidBodyBase, _RigidRodSymplecticStepperMixin):
             self.rate_collection[2:-1], (2, 3 * self.n_elems)
         )
 
-        for k, v in map_rate_collection.items():
+    def _map_system_properties_to_block_memory(
+        self,
+        mapping_dict: dict,
+        systems: Sequence,
+        block_memory: np.ndarray,
+        value_type: Literal["scalar", "vector", "tensor"],
+    ) -> None:
+        """Map system (rigid bodies) properties to memory blocks.
+
+        Parameters
+        ----------
+        mapping_dict: dict
+            Dictionary with attribute names as keys and block row index as values.
+        systems: Sequence
+            A sequence containing Cosserat rod objects to map from.
+        block_memory: ndarray
+            Memory block that, at the end of the method execution, contains all designated
+            attributes of all systems.
+        value_type: str
+            A string that indicates the shape of the attribute.
+            Options among "scalar", "vector", and "tensor".
+
+        """
+        if value_type == "scalar":
+            view_shape = (self.n_elems,)
+
+        elif value_type == "vector":
+            view_shape = (3, self.n_elems)
+
+        elif value_type == "tensor":
+            view_shape = (3, 3, self.n_elems)
+
+        else:
+            raise ValueError(
+                "Incorrect value type. Must be one of scalar, vector, and tensor."
+            )
+
+        for k, v in mapping_dict.items():
+            self.__dict__[k] = np.lib.stride_tricks.as_strided(
+                block_memory[v],
+                shape=view_shape,
+            )
+
             for system_idx, system in enumerate(systems):
-                self.__dict__[k][..., system_idx : system_idx + 1] = system.__dict__[
-                    k
-                ].copy()
+                self.__dict__[k][..., system_idx : system_idx + 1] = (
+                    system.__dict__[k]
+                    if value_type == "scalar"
+                    else system.__dict__[k].copy()
+                )
                 system.__dict__[k] = np.ndarray.view(
                     self.__dict__[k][..., system_idx : system_idx + 1]
                 )

--- a/elastica/memory_block/memory_block_rod.py
+++ b/elastica/memory_block/memory_block_rod.py
@@ -1,6 +1,6 @@
 __doc__ = """Create block-structure class for collection of Cosserat rod systems."""
 import numpy as np
-from typing import Sequence
+from typing import Sequence, Literal, Callable
 from elastica.memory_block.memory_block_rod_base import (
     MemoryBlockRodBase,
     make_block_memory_metadata,
@@ -236,23 +236,13 @@ class MemoryBlockCosseratRod(
         self.scalar_dofs_in_rod_nodes = np.zeros(
             (len(map_scalar_dofs_in_rod_nodes), self.n_nodes)
         )
-        for k, v in map_scalar_dofs_in_rod_nodes.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.scalar_dofs_in_rod_nodes[v], (self.n_nodes,)
-            )
-
-        for k, v in map_scalar_dofs_in_rod_nodes.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_nodes[system_idx]
-                end_idx = self.end_idx_in_rod_nodes[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic node boundaries
-            _synchronize_periodic_boundary_of_scalar_collection(
-                self.__dict__[k], self.periodic_boundary_nodes_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_scalar_dofs_in_rod_nodes,
+            systems=systems,
+            block_memory=self.scalar_dofs_in_rod_nodes,
+            domain_type="node",
+            value_type="scalar",
+        )
 
         # Things in nodes that are vectors
         #             0 ("position_collection", float64[:, :]),
@@ -267,26 +257,13 @@ class MemoryBlockCosseratRod(
         self.vector_dofs_in_rod_nodes = np.zeros(
             (len(map_vector_dofs_in_rod_nodes), 3 * self.n_nodes)
         )
-        for k, v in map_vector_dofs_in_rod_nodes.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.vector_dofs_in_rod_nodes[v], (3, self.n_nodes)
-            )
-
-        for k, v in map_vector_dofs_in_rod_nodes.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_nodes[system_idx]
-                end_idx = self.end_idx_in_rod_nodes[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic node boundaries
-            _synchronize_periodic_boundary_of_vector_collection(
-                self.__dict__[k], self.periodic_boundary_nodes_idx
-            )
-
-        # Things in nodes that are matrices
-        # Null set
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_vector_dofs_in_rod_nodes,
+            systems=systems,
+            block_memory=self.vector_dofs_in_rod_nodes,
+            domain_type="node",
+            value_type="vector",
+        )
 
     def _allocate_block_variables_in_elements(self, systems: Sequence):
         """
@@ -323,23 +300,13 @@ class MemoryBlockCosseratRod(
         self.scalar_dofs_in_rod_elems = np.zeros(
             (len(map_scalar_dofs_in_rod_elems), self.n_elems)
         )
-        for k, v in map_scalar_dofs_in_rod_elems.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.scalar_dofs_in_rod_elems[v], (self.n_elems,)
-            )
-
-        for k, v in map_scalar_dofs_in_rod_elems.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_elems[system_idx]
-                end_idx = self.end_idx_in_rod_elems[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic element boundaries
-            _synchronize_periodic_boundary_of_scalar_collection(
-                self.__dict__[k], self.periodic_boundary_elems_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_scalar_dofs_in_rod_elems,
+            systems=systems,
+            block_memory=self.scalar_dofs_in_rod_elems,
+            domain_type="element",
+            value_type="scalar",
+        )
 
         # Things in elements that are vectors
         #             0 ("tangents", float64[:, :]),
@@ -359,23 +326,13 @@ class MemoryBlockCosseratRod(
         self.vector_dofs_in_rod_elems = np.zeros(
             (len(map_vector_dofs_in_rod_elems), 3 * self.n_elems)
         )
-        for k, v in map_vector_dofs_in_rod_elems.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.vector_dofs_in_rod_elems[v], (3, self.n_elems)
-            )
-
-        for k, v in map_vector_dofs_in_rod_elems.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_elems[system_idx]
-                end_idx = self.end_idx_in_rod_elems[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic element boundaries
-            _synchronize_periodic_boundary_of_vector_collection(
-                self.__dict__[k], self.periodic_boundary_elems_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_vector_dofs_in_rod_elems,
+            systems=systems,
+            block_memory=self.vector_dofs_in_rod_elems,
+            domain_type="element",
+            value_type="vector",
+        )
 
         # Things in elements that are matrices
         #             0 ("director_collection", float64[:, :, :]),
@@ -391,23 +348,13 @@ class MemoryBlockCosseratRod(
         self.matrix_dofs_in_rod_elems = np.zeros(
             (len(map_matrix_dofs_in_rod_elems), 9 * self.n_elems)
         )
-        for k, v in map_matrix_dofs_in_rod_elems.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.matrix_dofs_in_rod_elems[v], (3, 3, self.n_elems)
-            )
-
-        for k, v in map_matrix_dofs_in_rod_elems.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_elems[system_idx]
-                end_idx = self.end_idx_in_rod_elems[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic element boundaries
-            _synchronize_periodic_boundary_of_matrix_collection(
-                self.__dict__[k], self.periodic_boundary_elems_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_matrix_dofs_in_rod_elems,
+            systems=systems,
+            block_memory=self.matrix_dofs_in_rod_elems,
+            domain_type="element",
+            value_type="tensor",
+        )
 
     def _allocate_blocks_variables_in_voronoi(self, systems: Sequence):
         """
@@ -434,23 +381,13 @@ class MemoryBlockCosseratRod(
         self.scalar_dofs_in_rod_voronois = np.zeros(
             (len(map_scalar_dofs_in_rod_voronois), self.n_voronoi)
         )
-        for k, v in map_scalar_dofs_in_rod_voronois.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.scalar_dofs_in_rod_voronois[v], (self.n_voronoi,)
-            )
-
-        for k, v in map_scalar_dofs_in_rod_voronois.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_voronoi[system_idx]
-                end_idx = self.end_idx_in_rod_voronoi[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic voronoi boundaries
-            _synchronize_periodic_boundary_of_scalar_collection(
-                self.__dict__[k], self.periodic_boundary_voronoi_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_scalar_dofs_in_rod_voronois,
+            systems=systems,
+            block_memory=self.scalar_dofs_in_rod_voronois,
+            domain_type="voronoi",
+            value_type="scalar",
+        )
 
         # Things in voronoi that are vectors
         #             0 ("kappa", float64[:, :]),
@@ -464,23 +401,13 @@ class MemoryBlockCosseratRod(
         self.vector_dofs_in_rod_voronois = np.zeros(
             (len(map_vector_dofs_in_rod_voronois), 3 * self.n_voronoi)
         )
-        for k, v in map_vector_dofs_in_rod_voronois.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.vector_dofs_in_rod_voronois[v], (3, self.n_voronoi)
-            )
-
-        for k, v in map_vector_dofs_in_rod_voronois.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_voronoi[system_idx]
-                end_idx = self.end_idx_in_rod_voronoi[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic voronoi boundaries
-            _synchronize_periodic_boundary_of_vector_collection(
-                self.__dict__[k], self.periodic_boundary_voronoi_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_vector_dofs_in_rod_voronois,
+            systems=systems,
+            block_memory=self.vector_dofs_in_rod_voronois,
+            domain_type="voronoi",
+            value_type="vector",
+        )
 
         # Things in voronoi that are matrices
         #             0 ("bend_matrix", float64[:, :, :]),
@@ -488,24 +415,13 @@ class MemoryBlockCosseratRod(
         self.matrix_dofs_in_rod_voronois = np.zeros(
             (len(map_matrix_dofs_in_rod_voronois), 9 * self.n_voronoi)
         )
-
-        for k, v in map_matrix_dofs_in_rod_voronois.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.matrix_dofs_in_rod_voronois[v], (3, 3, self.n_voronoi)
-            )
-
-        for k, v in map_matrix_dofs_in_rod_voronois.items():
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_voronoi[system_idx]
-                end_idx = self.end_idx_in_rod_voronoi[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic voronoi boundaries
-            _synchronize_periodic_boundary_of_matrix_collection(
-                self.__dict__[k], self.periodic_boundary_voronoi_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_matrix_dofs_in_rod_voronois,
+            systems=systems,
+            block_memory=self.matrix_dofs_in_rod_voronois,
+            domain_type="voronoi",
+            value_type="tensor",
+        )
 
     def _allocate_blocks_variables_for_symplectic_stepper(self, systems: Sequence):
         """
@@ -550,39 +466,129 @@ class MemoryBlockCosseratRod(
             "velocity_collection": 0,
             "acceleration_collection": 2,
         }
-        for k, v in map_rate_collection_dofs_in_rod_nodes.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.rate_collection[v], (3, self.n_nodes)
-            )
-            for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_nodes[system_idx]
-                end_idx = self.end_idx_in_rod_nodes[system_idx]
-                self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
-                system.__dict__[k] = np.ndarray.view(
-                    self.__dict__[k][..., start_idx:end_idx]
-                )
-            # synchronize the periodic node boundaries
-            _synchronize_periodic_boundary_of_vector_collection(
-                self.__dict__[k], self.periodic_boundary_nodes_idx
-            )
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_rate_collection_dofs_in_rod_nodes,
+            systems=systems,
+            block_memory=self.rate_collection,
+            domain_type="node",
+            value_type="vector",
+        )
 
         # Copy systems variables on elements to block structure
         map_rate_collection_dofs_in_rod_elems = {
             "omega_collection": 1,
             "alpha_collection": 3,
         }
-        for k, v in map_rate_collection_dofs_in_rod_elems.items():
-            self.__dict__[k] = np.lib.stride_tricks.as_strided(
-                self.rate_collection[v], (3, self.n_elems)
+        self._map_system_properties_to_block_memory(
+            mapping_dict=map_rate_collection_dofs_in_rod_elems,
+            systems=systems,
+            block_memory=self.rate_collection,
+            domain_type="element",
+            value_type="vector",
+        )
+
+    def _map_system_properties_to_block_memory(
+        self,
+        mapping_dict: dict,
+        systems: Sequence,
+        block_memory: np.ndarray,
+        domain_type: Literal["node", "element", "voronoi"],
+        value_type: Literal["scalar", "vector", "tensor"],
+    ) -> None:
+        """Map system (Cosserat rods) properties to memory blocks.
+
+        This method take domain types (node, element, voronoi) and value
+        types (scalar, vector, tensor) as inputs and compute internally how to
+        construct the mapping properly.
+
+        Parameters
+        ----------
+        mapping_dict: dict
+            Dictionary with attribute names as keys and block row index as values.
+        systems: Sequence
+            A sequence containing Cosserat rod objects to map from.
+        block_memory: ndarray
+            Memory block that, at the end of the method execution, contains all designated
+            attributes of all systems.
+        domain_type: str
+            A string that indicates the discretized domain where the attributes reside.
+            Options among "node", "element", and "voronoi".
+        value_type: str
+            A string that indicates the shape of the attribute.
+            Options among "scalar", "vector", and "tensor".
+
+        """
+
+        # typedef
+        start_idx_list: np.ndarray
+        end_idx_list: np.ndarray
+        periodic_boundary_idx: np.ndarray
+        synchronize_periodic_boundary: Callable
+        domain_num: np.int64
+        view_shape: tuple
+
+        if domain_type == "node":
+            start_idx_list = self.start_idx_in_rod_nodes.view()
+            end_idx_list = self.end_idx_in_rod_nodes.view()
+            domain_num = self.n_nodes
+            periodic_boundary_idx = self.periodic_boundary_nodes_idx.view()
+
+        elif domain_type == "element":
+            start_idx_list = self.start_idx_in_rod_elems.view()
+            end_idx_list = self.end_idx_in_rod_elems.view()
+            domain_num = self.n_elems
+            periodic_boundary_idx = self.periodic_boundary_elems_idx.view()
+
+        elif domain_type == "voronoi":
+            start_idx_list = self.start_idx_in_rod_voronoi.view()
+            end_idx_list = self.end_idx_in_rod_voronoi.view()
+            domain_num = self.n_voronoi
+            periodic_boundary_idx = self.periodic_boundary_voronoi_idx.view()
+
+        else:
+            raise ValueError(
+                "Incorrect domain type. Must be one of node, element, and voronoi"
             )
+
+        if value_type == "scalar":
+            view_shape = (domain_num,)
+            synchronize_periodic_boundary = (
+                _synchronize_periodic_boundary_of_scalar_collection
+            )
+
+        elif value_type == "vector":
+            view_shape = (3, domain_num)
+            synchronize_periodic_boundary = (
+                _synchronize_periodic_boundary_of_vector_collection
+            )
+
+        elif value_type == "tensor":
+            view_shape = (3, 3, domain_num)
+            synchronize_periodic_boundary = (
+                _synchronize_periodic_boundary_of_matrix_collection
+            )
+
+        else:
+            raise ValueError(
+                "Incorrect value type. Must be one of scalar, vector, and tensor."
+            )
+
+        for k, v in mapping_dict.items():
+            # Map class attributes to block memory
+            self.__dict__[k] = np.lib.stride_tricks.as_strided(
+                block_memory[v],
+                shape=view_shape,
+            )
+
+            # Copy system attributes into block memory, then make system attributes
+            # views into the block memory
             for system_idx, system in enumerate(systems):
-                start_idx = self.start_idx_in_rod_elems[system_idx]
-                end_idx = self.end_idx_in_rod_elems[system_idx]
+                start_idx = start_idx_list[system_idx]
+                end_idx = end_idx_list[system_idx]
                 self.__dict__[k][..., start_idx:end_idx] = system.__dict__[k].copy()
                 system.__dict__[k] = np.ndarray.view(
                     self.__dict__[k][..., start_idx:end_idx]
                 )
-            # synchronize the periodic node boundaries
-            _synchronize_periodic_boundary_of_vector_collection(
-                self.__dict__[k], self.periodic_boundary_elems_idx
-            )
+
+            # Synchronize periodic boundaries
+            synchronize_periodic_boundary(self.__dict__[k], periodic_boundary_idx)

--- a/elastica/memory_block/memory_block_rod.py
+++ b/elastica/memory_block/memory_block_rod.py
@@ -142,39 +142,24 @@ class MemoryBlockCosseratRod(
                     self.ghost_voronoi_idx[2::3][n_straight_rods - 1] + 1
                 )
 
-                # Compute the start and end of the rod nodes again. This time, boundary cells are added.
-                self.start_idx_in_rod_nodes[n_straight_rods:] = (
-                    self.periodic_boundary_nodes_idx[0, 0::3] + 1
-                )
-                self.end_idx_in_rod_nodes[
-                    n_straight_rods:
-                ] = self.periodic_boundary_nodes_idx[0, 1::3]
+            # Compute the start and end of the rod nodes again. This time, boundary cells are added.
+            self.start_idx_in_rod_nodes[n_straight_rods:] = (
+                self.periodic_boundary_nodes_idx[0, 0::3] + 1
+            )
+            self.end_idx_in_rod_nodes[
+                n_straight_rods:
+            ] = self.periodic_boundary_nodes_idx[0, 1::3]
 
-                self.start_idx_in_rod_elems[n_straight_rods:] = (
-                    self.periodic_boundary_elems_idx[0, 0::2] + 1
-                )
-                self.end_idx_in_rod_elems[
-                    n_straight_rods:
-                ] = self.periodic_boundary_elems_idx[0, 1::2]
+            self.start_idx_in_rod_elems[n_straight_rods:] = (
+                self.periodic_boundary_elems_idx[0, 0::2] + 1
+            )
+            self.end_idx_in_rod_elems[
+                n_straight_rods:
+            ] = self.periodic_boundary_elems_idx[0, 1::2]
 
-                self.start_idx_in_rod_voronoi[n_straight_rods:] = (
-                    self.periodic_boundary_voronoi_idx[0, :] + 1
-                )
-            else:
-                # Compute the start and end of the rod nodes again. This time, boundary cells are added.
-                self.start_idx_in_rod_nodes[:] = (
-                    self.periodic_boundary_nodes_idx[0, 0::3] + 1
-                )
-                self.end_idx_in_rod_nodes[:] = self.periodic_boundary_nodes_idx[0, 1::3]
-
-                self.start_idx_in_rod_elems[:] = (
-                    self.periodic_boundary_elems_idx[0, 0::2] + 1
-                )
-                self.end_idx_in_rod_elems[:] = self.periodic_boundary_elems_idx[0, 1::2]
-
-                self.start_idx_in_rod_voronoi[:] = (
-                    self.periodic_boundary_voronoi_idx[0, :] + 1
-                )
+            self.start_idx_in_rod_voronoi[n_straight_rods:] = (
+                self.periodic_boundary_voronoi_idx[0, :] + 1
+            )
 
         # Allocate block structure using system collection.
         self._allocate_block_variables_in_nodes(systems)

--- a/elastica/memory_block/memory_block_rod.py
+++ b/elastica/memory_block/memory_block_rod.py
@@ -548,7 +548,7 @@ class MemoryBlockCosseratRod(
         # Copy systems variables on nodes to block structure
         map_rate_collection_dofs_in_rod_nodes = {
             "velocity_collection": 0,
-            "acceleration_collection": 1,
+            "acceleration_collection": 2,
         }
         for k, v in map_rate_collection_dofs_in_rod_nodes.items():
             self.__dict__[k] = np.lib.stride_tricks.as_strided(
@@ -568,8 +568,8 @@ class MemoryBlockCosseratRod(
 
         # Copy systems variables on elements to block structure
         map_rate_collection_dofs_in_rod_elems = {
-            "omega_collection": 0,
-            "alpha_collection": 1,
+            "omega_collection": 1,
+            "alpha_collection": 3,
         }
         for k, v in map_rate_collection_dofs_in_rod_elems.items():
             self.__dict__[k] = np.lib.stride_tricks.as_strided(

--- a/tests/test_modules/test_memory_block_base.py
+++ b/tests/test_modules/test_memory_block_base.py
@@ -8,7 +8,6 @@ from elastica.memory_block.memory_block_rod_base import (
 )
 
 
-@pytest.mark.module
 @pytest.mark.parametrize(
     "n_elems_in_rods, outputs",
     [

--- a/tests/test_modules/test_memory_block_base.py
+++ b/tests/test_modules/test_memory_block_base.py
@@ -1,0 +1,73 @@
+__doc__ = """ Test make_block_memory_metadata and make_block_memory_periodic_boundary_metadata functions """
+
+import pytest
+import numpy as np
+from elastica.memory_block.memory_block_rod_base import (
+    make_block_memory_metadata,
+    make_block_memory_periodic_boundary_metadata,
+)
+
+
+@pytest.mark.module
+@pytest.mark.parametrize(
+    "n_elems_in_rods, outputs",
+    [
+        (
+            np.array([5], dtype=np.int64),
+            [
+                np.int64(5),
+                np.array([], dtype=np.int64),
+                np.array([], dtype=np.int64),
+                np.array([], dtype=np.int64),
+            ],
+        ),
+        (
+            np.array([5, 5], dtype=np.int64),
+            [
+                np.int64(12),
+                np.array([6], dtype=np.int64),
+                np.array([5, 6], dtype=np.int64),
+                np.array([4, 5, 6], dtype=np.int64),
+            ],
+        ),
+        (
+            np.array([1, 1, 1], dtype=np.int64),
+            [
+                np.int64(7),
+                np.array([2, 5], dtype=np.int64),
+                np.array([1, 2, 4, 5], dtype=np.int64),
+                np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
+            ],
+        ),
+        (
+            np.array([1, 2, 3], dtype=np.int64),
+            [
+                np.int64(10),
+                np.array([2, 6], dtype=np.int64),
+                np.array([1, 2, 5, 6], dtype=np.int64),
+                np.array([0, 1, 2, 4, 5, 6], dtype=np.int64),
+            ],
+        ),
+        (
+            np.array([10, 10, 5, 5], dtype=np.int64),
+            [
+                np.int64(36),
+                np.array([11, 23, 30], dtype=np.int64),
+                np.array([10, 11, 22, 23, 29, 30], dtype=np.int64),
+                np.array([9, 10, 11, 21, 22, 23, 28, 29, 30], dtype=np.int64),
+            ],
+        ),
+    ],
+)
+def test_make_block_memory_metadata(n_elems_in_rods, outputs):
+    [
+        n_elems_with_ghosts,
+        ghost_nodes_idx,
+        ghost_elems_idx,
+        ghost_voronoi_idx,
+    ] = make_block_memory_metadata(n_elems_in_rods)
+
+    assert np.all(n_elems_with_ghosts == outputs[0])
+    assert np.all(ghost_nodes_idx == outputs[1])
+    assert np.all(ghost_elems_idx == outputs[2])
+    assert np.all(ghost_voronoi_idx == outputs[3])

--- a/tests/test_modules/test_memory_block_base.py
+++ b/tests/test_modules/test_memory_block_base.py
@@ -2,6 +2,7 @@ __doc__ = """ Test make_block_memory_metadata and make_block_memory_periodic_bou
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 from elastica.memory_block.memory_block_rod_base import (
     make_block_memory_metadata,
     make_block_memory_periodic_boundary_metadata,
@@ -59,14 +60,60 @@ from elastica.memory_block.memory_block_rod_base import (
     ],
 )
 def test_make_block_memory_metadata(n_elems_in_rods, outputs):
-    [
+    (
         n_elems_with_ghosts,
         ghost_nodes_idx,
         ghost_elems_idx,
         ghost_voronoi_idx,
-    ] = make_block_memory_metadata(n_elems_in_rods)
+    ) = make_block_memory_metadata(n_elems_in_rods)
 
-    assert np.all(n_elems_with_ghosts == outputs[0])
-    assert np.all(ghost_nodes_idx == outputs[1])
-    assert np.all(ghost_elems_idx == outputs[2])
-    assert np.all(ghost_voronoi_idx == outputs[3])
+    assert_array_equal(n_elems_with_ghosts, outputs[0])
+    assert_array_equal(ghost_nodes_idx, outputs[1])
+    assert_array_equal(ghost_elems_idx, outputs[2])
+    assert_array_equal(ghost_voronoi_idx, outputs[3])
+
+
+@pytest.mark.parametrize(
+    "n_elems_in_ring_rods",
+    [
+        np.array([10], dtype=np.int64),
+        np.array([2, 4], dtype=np.int64),
+        np.array([4, 5, 7], dtype=np.int64),
+        np.array([10, 10, 10, 10], dtype=np.int64),
+    ],
+)
+def test_make_block_memory_periodic_boundary_metadata(n_elems_in_ring_rods):
+    (
+        n_elem,
+        periodic_boundary_node_idx,
+        periodic_boundary_elems_idx,
+        periodic_boundary_voronoi_idx,
+    ) = make_block_memory_periodic_boundary_metadata(n_elems_in_ring_rods)
+
+    n_ring_rods = len(n_elems_in_ring_rods)
+    expected_n_elem = n_elems_in_ring_rods + 2
+    expected_node_idx = np.empty((2, 3 * n_ring_rods), dtype=np.int64)
+    expected_element_idx = np.empty((2, 2 * n_ring_rods), dtype=np.int64)
+    expected_voronoi_idx = np.empty((2, n_ring_rods), dtype=np.int64)
+
+    accumulation = np.hstack((0, np.cumsum(n_elems_in_ring_rods[:-1] + 4)))
+
+    expected_node_idx[0, 0::3] = accumulation
+    expected_node_idx[0, 1::3] = accumulation + n_elems_in_ring_rods + 1
+    expected_node_idx[0, 2::3] = accumulation + n_elems_in_ring_rods + 2
+    expected_node_idx[1, 0::3] = accumulation + n_elems_in_ring_rods
+    expected_node_idx[1, 1::3] = accumulation + 1
+    expected_node_idx[1, 2::3] = accumulation + 2
+
+    expected_element_idx[0, 0::2] = accumulation
+    expected_element_idx[0, 1::2] = accumulation + n_elems_in_ring_rods + 1
+    expected_element_idx[1, 0::2] = accumulation + n_elems_in_ring_rods
+    expected_element_idx[1, 1::2] = accumulation + 1
+
+    expected_voronoi_idx[0, :] = accumulation
+    expected_voronoi_idx[1, :] = accumulation + n_elems_in_ring_rods
+
+    assert_array_equal(n_elem, expected_n_elem)
+    assert_array_equal(periodic_boundary_node_idx, expected_node_idx)
+    assert_array_equal(periodic_boundary_elems_idx, expected_element_idx)
+    assert_array_equal(periodic_boundary_voronoi_idx, expected_voronoi_idx)

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -2,6 +2,7 @@ __doc__ = """" Test modules to construct memory block for Cosserat rods """
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from elastica.rod import RodBase
 from elastica.modules.memory_block import construct_memory_block_structures
@@ -182,6 +183,6 @@ def test_memory_block_rod_straight_rods(n_rods):
             )
 
             # Assert that the rod's and memory block's attributes are equal in values
-            assert np.all(
-                system.__dict__[attr] == block_view[..., start_idx[k] : end_idx[k]]
+            assert_array_equal(
+                block_view[..., start_idx[k] : end_idx[k]], system.__dict__[attr]
             )

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -86,7 +86,10 @@ def test_construct_memory_block_structures_for_cosserat_rod(n_rods):
 
     """
 
-    systems = [BaseRodForTesting(np.random.randint(10, 30 + 1)) for _ in range(n_rods)]
+    systems = [
+        BaseRodForTesting(np.random.randint(10, 30 + 1), ring_rod_flag=False)
+        for _ in range(n_rods)
+    ]
 
     memory_block_list = construct_memory_block_structures(systems)
 

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -175,17 +175,6 @@ def test_memory_block_rod(n_straight_rods, n_ring_rods):
         "alpha_collection": "element",
     }
 
-    # Self check: make sure memory block attributes do not share memory with each other
-    for attr_x in expected_attr_dict:
-        for attr_y in expected_attr_dict:
-            if attr_x == attr_y:
-                continue
-
-            assert not np.may_share_memory(
-                memory_block.__dict__[attr_x],
-                memory_block.__dict__[attr_y],
-            )
-
     # Cross check: make sure memory block and rod attributes are views of each other
     for attr, domain in expected_attr_dict.items():
         # Check if the memory block has the attribute
@@ -204,4 +193,15 @@ def test_memory_block_rod(n_straight_rods, n_ring_rods):
             # Assert that the rod's and memory block's attributes are equal in values
             assert_array_equal(
                 block_view[..., start_idx[i] : end_idx[i]], systems[k].__dict__[attr]
+            )
+
+    # Self check: make sure memory block attributes do not share memory with each other
+    for attr_x in expected_attr_dict:
+        for attr_y in expected_attr_dict:
+            if attr_x == attr_y:
+                continue
+
+            assert not np.may_share_memory(
+                memory_block.__dict__[attr_x],
+                memory_block.__dict__[attr_y],
             )

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -154,6 +154,18 @@ def test_memory_block_rod_straight_rods(n_rods):
         "alpha_collection": "element",
     }
 
+    # Self check: make sure memory block attributes do not share memory with each other
+    for attr_x in expected_attr_dict:
+        for attr_y in expected_attr_dict:
+            if attr_x == attr_y:
+                continue
+
+            assert not np.may_share_memory(
+                memory_block.__dict__[attr_x],
+                memory_block.__dict__[attr_y],
+            )
+
+    # Cross check: make sure memory block and rod attributes are views of each other
     for attr, domain in expected_attr_dict.items():
         # Check if the memory block has the attribute
         assert attr in attr_list

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -1,4 +1,4 @@
-__doc__ = """" Test modules to construct memory block """
+__doc__ = """" Test modules to construct memory block for Cosserat rods """
 
 import pytest
 import numpy as np

--- a/tests/test_modules/test_memory_block_cosserat_rod.py
+++ b/tests/test_modules/test_memory_block_cosserat_rod.py
@@ -96,6 +96,20 @@ def test_construct_memory_block_structures_for_cosserat_rod(n_rods):
 @pytest.mark.parametrize("n_straight_rods", [0, 1, 2, 5])
 @pytest.mark.parametrize("n_ring_rods", [0, 1, 2, 5])
 def test_memory_block_rod(n_straight_rods, n_ring_rods):
+    """
+    Test memory block logic for Cosserat rods. This test suite supports
+    a mixture of straight rods and ring rods, the order of which is internally
+    randomized. Correct system indexing is required within the memory block
+    implementation to pass this test.
+
+    Parameters
+    ----------
+    n_straight_rods: int
+        Number of straight rods.
+    n_ring_rods: int
+        Number of ring rods.
+
+    """
 
     n_rods = n_straight_rods + n_ring_rods
 

--- a/tests/test_modules/test_memory_block_rigid_body.py
+++ b/tests/test_modules/test_memory_block_rigid_body.py
@@ -65,7 +65,7 @@ def test_construct_memory_block_structures_for_rigid_bodies(n_bodies):
     assert issubclass(memory_block_list[0].__class__, MemoryBlockRigidBody)
 
 
-@pytest.mark.parametrize("n_bodies", [5])
+@pytest.mark.parametrize("n_bodies", [1, 2, 5, 6])
 def test_memory_block_rigid_body(n_bodies):
     """
     Test memory block logic for rigid bodies.

--- a/tests/test_modules/test_memory_block_rigid_body.py
+++ b/tests/test_modules/test_memory_block_rigid_body.py
@@ -1,0 +1,133 @@
+import pytest
+import numpy as np
+import scipy as sp
+
+from numpy.testing import assert_array_equal
+
+from elastica.rigidbody import RigidBodyBase
+from elastica.modules.memory_block import construct_memory_block_structures
+from elastica.memory_block.memory_block_rigid_body import MemoryBlockRigidBody
+
+
+class MockRigidBodyForTesting(RigidBodyBase):
+    def __init__(self):
+        super().__init__()
+        self.radius = np.random.uniform(low=1, high=5)
+        self.length = np.random.uniform(low=1, high=10)
+        self.density = np.random.uniform(low=1, high=10)
+        self.volume = self.length * self.radius * self.radius
+        self.mass = np.array(self.volume * self.density)
+
+        self.position_collection = np.random.rand(3, 1)
+        self.external_forces = np.random.rand(3, 1)
+        self.external_torques = np.random.rand(3, 1)
+
+        self.director_collection = sp.linalg.qr(np.random.rand(3, 3))[0].reshape(
+            3, 3, 1
+        )
+
+        mass_second_moi_diag = (
+            np.random.uniform(low=1, high=2, size=(3,))
+            * self.radius
+            * self.length
+            * self.density
+        )
+
+        self.mass_second_moment_of_inertia = np.diag(mass_second_moi_diag).reshape(
+            (3, 3, 1)
+        )
+        self.inv_mass_second_moment_of_inertia = np.diag(
+            1.0 / mass_second_moi_diag
+        ).reshape((3, 3, 1))
+
+        self.velocity_collection = np.random.rand(3, 1)
+        self.acceleration_collection = np.random.rand(3, 1)
+        self.omega_collection = np.random.rand(3, 1)
+        self.alpha_collection = np.random.rand(3, 1)
+
+
+@pytest.mark.parametrize("n_bodies", [1, 2, 5, 6])
+def test_construct_memory_block_structures_for_rigid_bodies(n_bodies):
+    """
+    This test is only testing the validity of created rigid-body block-structure class,
+    using the construct_memory_block_structures function.
+
+    Parameters
+    ----------
+    n_bodies: int
+        Number of rigid bodies to pass into memory block constructor.
+    """
+
+    systems = [MockRigidBodyForTesting() for _ in range(n_bodies)]
+
+    memory_block_list = construct_memory_block_structures(systems)
+
+    assert issubclass(memory_block_list[0].__class__, MemoryBlockRigidBody)
+
+
+@pytest.mark.parametrize("n_bodies", [5])
+def test_memory_block_rigid_body(n_bodies):
+    """
+    Test memory block logic for rigid bodies.
+
+    Parameters
+    ----------
+    n_bodies: int
+        Number of rigid bodies to be passed into memory block.
+    """
+
+    systems = [MockRigidBodyForTesting() for _ in range(n_bodies)]
+    system_idx_list = np.arange(n_bodies)
+
+    memory_block = MemoryBlockRigidBody(systems, system_idx_list)
+
+    assert memory_block.n_bodies == n_bodies
+    assert memory_block.n_elems == n_bodies
+    assert memory_block.n_nodes == n_bodies
+
+    attr_list = dir(memory_block)
+
+    expected_attr_list = [
+        "mass",
+        "radius",
+        "volume",
+        "density",
+        "length",
+        "position_collection",
+        "external_forces",
+        "external_torques",
+        "director_collection",
+        "mass_second_moment_of_inertia",
+        "inv_mass_second_moment_of_inertia",
+        "velocity_collection",
+        "omega_collection",
+        "acceleration_collection",
+        "alpha_collection",
+    ]
+
+    # Cross check: make sure memory block and rod attributes are views of each other
+    for attr in expected_attr_list:
+        # Check if the memory block has the attribute
+        assert attr in attr_list
+
+        block_view = memory_block.__dict__[attr].view()
+
+        for k in memory_block.system_idx_list:
+            # Assert that the rod's and memory block's attributes share memory
+            assert np.shares_memory(
+                block_view[..., k : k + 1], systems[k].__dict__[attr]
+            )
+
+            # Assert that the rod's and memory block's attributes are equal in values
+            assert_array_equal(block_view[..., k : k + 1], systems[k].__dict__[attr])
+
+    # Self check: make sure memory block attributes do not share memory with each other
+    for attr_x in expected_attr_list:
+        for attr_y in expected_attr_list:
+            if attr_x == attr_y:
+                continue
+
+            assert not np.may_share_memory(
+                memory_block.__dict__[attr_x],
+                memory_block.__dict__[attr_y],
+            )


### PR DESCRIPTION
Refactor memory block implementation:
* Add `_map_system_properties_to_block_memory` method for both Cosserat rod and rigid bodies memory blocks to avoid code repetition. 
* Slight modifications in `make_block_memory_metadata` function without change in functionality
* Minor changes in function naming and docstrings

Test suites for memory blocks:
* Add test cases for `make_block_memory_metadata()` and `make_block_memory_periodic_boundary_metadata()`
* Add test cases for rigid-body memory block logic and implementation
* Add test cases for Cosserat rod memory block logic and implementation (ring rod supported)