### PR TITLE
RodPlaneContact and RodPlaneContactWithAnisotropicFriction Classes

### DIFF
--- a/elastica/__init__.py
+++ b/elastica/__init__.py
@@ -11,6 +11,7 @@ from elastica.rod.cosserat_rod import CosseratRod
 from elastica.rigidbody.rigid_body import RigidBodyBase
 from elastica.rigidbody.cylinder import Cylinder
 from elastica.rigidbody.sphere import Sphere
+from elastica.surface.plane import Plane
 from elastica.boundary_conditions import (
     ConstraintBase,
     FreeBC,
@@ -48,6 +49,8 @@ from elastica.contact_forces import (
     RodCylinderContact,
     RodSelfContact,
     RodSphereContact,
+    RodPlaneContact,
+    RodPlaneContactWithAnisotropicFriction,
 )
 from elastica.callback_functions import CallBackBaseClass, ExportCallBack, MyCallBack
 from elastica.dissipation import (

--- a/elastica/modules/base_system.py
+++ b/elastica/modules/base_system.py
@@ -169,9 +169,20 @@ class BaseSystemCollection(MutableSequence):
 
         # Toggle the finalize_flag
         self._finalize_flag = True
+        # sort _feature_group_synchronize so that _call_contacts is at the end
+        _call_contacts_index = []
+        for idx, feature in enumerate(self._feature_group_synchronize):
+            if feature.__name__ == "_call_contacts":
+                _call_contacts_index.append(idx)
+
+        # Move to the _call_contacts to the end of the _feature_group_synchronize list.
+        for index in _call_contacts_index:
+            self._feature_group_synchronize.append(
+                self._feature_group_synchronize.pop(index)
+            )
 
     def synchronize(self, time: float):
-        # Collection call _featuer_group_synchronize
+        # Collection call _feature_group_synchronize
         for feature in self._feature_group_synchronize:
             feature(time)
 

--- a/elastica/modules/memory_block.py
+++ b/elastica/modules/memory_block.py
@@ -5,6 +5,7 @@ Cosserat Rods, Rigid Body etc.
 
 from elastica.rod import RodBase
 from elastica.rigidbody import RigidBodyBase
+from elastica.surface import SurfaceBase
 from elastica.memory_block import MemoryBlockCosseratRod, MemoryBlockRigidBody
 
 
@@ -34,6 +35,9 @@ def construct_memory_block_structures(systems):
             temp_list_for_rigid_body_systems.append(sys_to_be_added)
             temp_list_for_rigid_body_systems_idx.append(system_idx)
 
+        elif issubclass(sys_to_be_added.__class__, SurfaceBase):
+            pass
+
         else:
             raise TypeError(
                 "{0}\n"
@@ -43,7 +47,9 @@ def construct_memory_block_structures(systems):
                 "satisfies all criteria for being a system, please add\n"
                 "it here with correct memory block implementation.\n"
                 "The allowed types are\n"
-                "{1} {2}".format(sys_to_be_added.__class__, RodBase, RigidBodyBase)
+                "{1} {2} {3}".format(
+                    sys_to_be_added.__class__, RodBase, RigidBodyBase, SurfaceBase
+                )
             )
 
     if temp_list_for_cosserat_rod_systems:


### PR DESCRIPTION
Fourth contact module PR mentioned in [Issue](https://github.com/GazzolaLab/PyElastica/issues/113) 
This PR includes:
- Added RodPlaneContact, and RodPlaneContactWithFriction which are based on InteractionPlane and AnisotropicFrictionalPlane from interaction.
- Updated base_system to call _call_contacts last (needed so the external forces are applied before contact)
- Updated memory_block to accept surface class when appended to the simulation
