### PR TITLE
Fixes #287 Removed Empty Return statements and Added methods in documentation

### DIFF
--- a/docs/api/external_forces.rst
+++ b/docs/api/external_forces.rst
@@ -63,7 +63,7 @@ Built-in External Forces
    :noindex:
 
 .. autoclass:: NoForces
-   :special-members: __init__
+   :special-members: __init__, apply_forces, apply_torques
 
 .. autoclass:: EndpointForces
    :special-members: __init__

--- a/elastica/external_forces.py
+++ b/elastica/external_forces.py
@@ -40,9 +40,6 @@ class NoForces:
         time : float
             The time of simulation.
 
-        Returns
-        -------
-
         """
         pass
 
@@ -57,9 +54,6 @@ class NoForces:
             Rod or rigid-body object
         time : float
             The time of simulation.
-
-        Returns
-        -------
 
         """
         pass

--- a/elastica/joint.py
+++ b/elastica/joint.py
@@ -61,8 +61,6 @@ class FreeJoint:
         index_two : int
             Index of second rod for joint.
 
-        Returns
-        -------
 
         """
         end_distance_vector = (
@@ -101,9 +99,6 @@ class FreeJoint:
             Rod or rigid-body object
         index_two : int
             Index of second rod for joint.
-
-        Returns
-        -------
 
         """
         pass


### PR DESCRIPTION
Fixes  #287 Refactor: function documentations for NoForcing and FreeJoint

1. Removed empty Return statements form apply_forces and apply_torques methods of classes NoForces & FreeJoint
2. In documentation, added apply_forces and apply_torques methods 