### PR TITLE
Explicit operation order determined by user definition

### DIFF
--- a/docs/guide/workflow.md
+++ b/docs/guide/workflow.md
@@ -89,7 +89,7 @@ This can be repeated to create multiple rods. Supported geometries are listed in
 The number of element (`n_elements`) and `base_length` determines the spatial discretization `dx`. More detail discussion is included [here](discretization.md).
 :::
 
-<h2>3. Define Boundary Conditions, Forcings, Damping and Connections</h2>
+<h2>3.a Define Boundary Conditions, Forcings, and Connections</h2>
 
 Now that we have added all our rods to `SystemSimulator`, we
 need to apply relevant boundary conditions.
@@ -123,6 +123,34 @@ SystemSimulator.add_forcing_to(rod1).using(
 )
 ```
 
+One last condition we can define is the connections between rods. See [this page](../api/connections.rst) for in-depth explanations and documentation.
+
+```python
+from elastica.connections import FixedJoint
+
+# Connect rod 1 and rod 2. '_connect_idx' specifies the node number that
+# the connection should be applied to. You are specifying the index of a
+# list so you can use -1 to access the last node.
+SystemSimulator.connect(
+    first_rod  = rod1,
+    second_rod = rod2,
+    first_connect_idx  = -1, # Connect to the last node of the first rod.
+    second_connect_idx =  0  # Connect to first node of the second rod.
+    ).using(
+        FixedJoint,  # Type of connection between rods
+        k  = 1e5,    # Spring constant of force holding rods together (F = k*x)
+        nu = 0,      # Energy dissipation of joint
+        kt = 5e3     # Rotational stiffness of rod to avoid rods twisting
+        )
+```
+
+:::{note}
+Version 0.3.3: The order of the operation is defined by the order of the definition. For example, if you define the connection before the forcing condition, the connection will be applied first. This is less important for the boundary condition, forcing, and connection since they do not depend on each other. However, it is important for friction, contact, or any custom boundary conditions since they depend on other boundary conditions.
+For example, friction should be defined after contact, since contact will define the normal force applied to the surface, which friction depends on. Contact should be defined before any other boundary conditions, since aggregated normal force is used to calculate the repelling force.
+:::
+
+<h2>3.b Define Damping </h2>
+
 Next, if required, in order to numerically stabilize the simulation,
 we can apply damping to the rods.
 See [this page](../api/damping.rst) for in-depth explanations and documentation.
@@ -146,26 +174,6 @@ SystemSimulator.dampin(rod2).using(
 )
 ```
 
-One last condition we can define is the connections between rods. See [this page](../api/connections.rst) for in-depth explanations and documentation.
-
-```python
-from elastica.connections import FixedJoint
-
-# Connect rod 1 and rod 2. '_connect_idx' specifies the node number that
-# the connection should be applied to. You are specifying the index of a
-# list so you can use -1 to access the last node.
-SystemSimulator.connect(
-    first_rod  = rod1,
-    second_rod = rod2,
-    first_connect_idx  = -1, # Connect to the last node of the first rod.
-    second_connect_idx =  0  # Connect to first node of the second rod.
-    ).using(
-        FixedJoint,  # Type of connection between rods
-        k  = 1e5,    # Spring constant of force holding rods together (F = k*x)
-        nu = 0,      # Energy dissipation of joint
-        kt = 5e3     # Rotational stiffness of rod to avoid rods twisting
-        )
-```
 
 <h2>4. Add Callback Functions (optional)</h2>
 

--- a/elastica/modules/base_system.py
+++ b/elastica/modules/base_system.py
@@ -32,11 +32,9 @@ class BaseSystemCollection(MutableSequence):
         _systems: list
             List of rod-like objects.
 
-    """
-
-    """
     Developer Note
     -----
+
     Note
     ----
     We can directly subclass a list for the
@@ -174,19 +172,19 @@ class BaseSystemCollection(MutableSequence):
     def synchronize(self, time: float):
         # Collection call _feature_group_synchronize
         for func in self._feature_group_synchronize:
-            func(time)
+            func(time=time)
 
     def constrain_values(self, time: float):
         # Collection call _feature_group_constrain_values
         for func in self._feature_group_constrain_values:
-            func(time)
+            func(time=time)
 
     def constrain_rates(self, time: float):
         # Collection call _feature_group_constrain_rates
         for func in self._feature_group_constrain_rates:
-            func(time)
+            func(time=time)
 
     def apply_callbacks(self, time: float, current_step: int):
         # Collection call _feature_group_callback
         for func in self._feature_group_callback:
-            func(time, current_step)
+            func(time=time, current_step=current_step)

--- a/elastica/modules/base_system.py
+++ b/elastica/modules/base_system.py
@@ -16,7 +16,7 @@ from elastica.surface import SurfaceBase
 from elastica._synchronize_periodic_boundary import _ConstrainPeriodicBoundaries
 
 from .memory_block import construct_memory_block_structures
-from .feature_group import FeatureGroupFIFO
+from .operator_group import OperatorGroupFIFO
 
 
 class BaseSystemCollection(MutableSequence):
@@ -46,7 +46,7 @@ class BaseSystemCollection(MutableSequence):
         # Collection of functions. Each group is executed as a collection at the different steps.
         # Each component (Forcing, Connection, etc.) registers the executable (callable) function
         # in the group that that needs to be executed. These should be initialized before mixin.
-        self._feature_group_synchronize: Iterable[OperatorType] = FeatureGroupFIFO()
+        self._feature_group_synchronize: Iterable[OperatorType] = OperatorGroupFIFO()
         self._feature_group_constrain_values: Iterable[OperatorType] = []
         self._feature_group_constrain_rates: Iterable[OperatorType] = []
         self._feature_group_callback: Iterable[OperatorCallbackType] = []

--- a/elastica/modules/base_system.py
+++ b/elastica/modules/base_system.py
@@ -5,15 +5,18 @@ Base System
 Basic coordinating for multiple, smaller systems that have an independently integrable
 interface (i.e. works with symplectic or explicit routines `timestepper.py`.)
 """
-from typing import Iterable, Callable, AnyStr
+from typing import AnyStr, Iterable
+from elastica.typing import OperatorType, OperatorCallbackType, OperatorFinalizeType
 
 from collections.abc import MutableSequence
 
 from elastica.rod import RodBase
 from elastica.rigidbody import RigidBodyBase
 from elastica.surface import SurfaceBase
-from elastica.modules.memory_block import construct_memory_block_structures
 from elastica._synchronize_periodic_boundary import _ConstrainPeriodicBoundaries
+
+from .memory_block import construct_memory_block_structures
+from .feature_group import FeatureGroupFIFO
 
 
 class BaseSystemCollection(MutableSequence):
@@ -45,13 +48,11 @@ class BaseSystemCollection(MutableSequence):
         # Collection of functions. Each group is executed as a collection at the different steps.
         # Each component (Forcing, Connection, etc.) registers the executable (callable) function
         # in the group that that needs to be executed. These should be initialized before mixin.
-        self._feature_group_synchronize: Iterable[Callable[[float], None]] = []
-        self._feature_group_constrain_values: Iterable[Callable[[float], None]] = []
-        self._feature_group_constrain_rates: Iterable[Callable[[float], None]] = []
-        self._feature_group_callback: Iterable[Callable[[float, int, AnyStr], None]] = (
-            []
-        )
-        self._feature_group_finalize: Iterable[Callable] = []
+        self._feature_group_synchronize: Iterable[OperatorType] = FeatureGroupFIFO()
+        self._feature_group_constrain_values: Iterable[OperatorType] = []
+        self._feature_group_constrain_rates: Iterable[OperatorType] = []
+        self._feature_group_callback: Iterable[OperatorCallbackType] = []
+        self._feature_group_finalize: Iterable[OperatorFinalizeType] = []
         # We need to initialize our mixin classes
         super(BaseSystemCollection, self).__init__()
         # List of system types/bases that are allowed
@@ -169,34 +170,23 @@ class BaseSystemCollection(MutableSequence):
 
         # Toggle the finalize_flag
         self._finalize_flag = True
-        # sort _feature_group_synchronize so that _call_contacts is at the end
-        _call_contacts_index = []
-        for idx, feature in enumerate(self._feature_group_synchronize):
-            if feature.__name__ == "_call_contacts":
-                _call_contacts_index.append(idx)
-
-        # Move to the _call_contacts to the end of the _feature_group_synchronize list.
-        for index in _call_contacts_index:
-            self._feature_group_synchronize.append(
-                self._feature_group_synchronize.pop(index)
-            )
 
     def synchronize(self, time: float):
         # Collection call _feature_group_synchronize
-        for feature in self._feature_group_synchronize:
-            feature(time)
+        for func in self._feature_group_synchronize:
+            func(time)
 
     def constrain_values(self, time: float):
         # Collection call _feature_group_constrain_values
-        for feature in self._feature_group_constrain_values:
-            feature(time)
+        for func in self._feature_group_constrain_values:
+            func(time)
 
     def constrain_rates(self, time: float):
         # Collection call _feature_group_constrain_rates
-        for feature in self._feature_group_constrain_rates:
-            feature(time)
+        for func in self._feature_group_constrain_rates:
+            func(time)
 
     def apply_callbacks(self, time: float, current_step: int):
         # Collection call _feature_group_callback
-        for feature in self._feature_group_callback:
-            feature(time, current_step)
+        for func in self._feature_group_callback:
+            func(time, current_step)

--- a/elastica/modules/connections.py
+++ b/elastica/modules/connections.py
@@ -99,12 +99,17 @@ class Connections:
                 connection, [apply_forces, apply_torques]
             )
 
+            self.warnings(connection)
+
         self._connections = []
         del self._connections
 
         # Need to finally solve CPP here, if we are doing things properly
         # This is to optimize the call tree for better memory accesses
         # https://brooksandrew.github.io/simpleblog/articles/intro-to-graph-optimization-solving-cpp/
+
+    def warnings(self, connection):
+        pass
 
 
 class _Connect:

--- a/elastica/modules/contact.py
+++ b/elastica/modules/contact.py
@@ -5,7 +5,6 @@ Contact
 Provides the contact interface to apply contact forces between objects
 (rods, rigid bodies, surfaces).
 """
-import functools
 from elastica.typing import SystemType, AllowedContactType
 
 
@@ -71,13 +70,15 @@ class Contact:
             )
 
             def apply_contact(time):
-                return functools.partial(
-                    contact_instance.apply_contact,
+                contact_instance.apply_contact(
                     system_one=self._systems[first_sys_idx],
                     system_two=self._systems[second_sys_idx],
                 )
 
             self._feature_group_synchronize.add_operators(contact, [apply_contact])
+
+        self._contacts = []
+        del self._contacts
 
 
 class _Contact:

--- a/elastica/modules/contact.py
+++ b/elastica/modules/contact.py
@@ -5,7 +5,10 @@ Contact
 Provides the contact interface to apply contact forces between objects
 (rods, rigid bodies, surfaces).
 """
+import logging
 from elastica.typing import SystemType, AllowedContactType
+
+logger = logging.getLogger(__name__)
 
 
 class Contact:
@@ -77,8 +80,18 @@ class Contact:
 
             self._feature_group_synchronize.add_operators(contact, [apply_contact])
 
+            self.warnings(contact)
+
         self._contacts = []
         del self._contacts
+
+    def warnings(self, contact):
+        from elastica.contact_forces import NoContact
+
+        # Classes that should be used last
+        if not self._feature_group_synchronize.is_last(contact):
+            if isinstance(contact._contact_cls, NoContact):
+                logger.warning("Contact features should be instantiated lastly.")
 
 
 class _Contact:

--- a/elastica/modules/feature_group.py
+++ b/elastica/modules/feature_group.py
@@ -14,8 +14,8 @@ class FeatureGroupFIFO(Iterable):
     >>> feature_group = FeatureGroupFIFO()
     >>> feature_group.append_id(obj_1)
     >>> feature_group.append_id(obj_2)
-    >>> feature_group.add_operators(obj_1, [OperatorType.ADD, OperatorType.SUBTRACT])
-    >>> feature_group.add_operators(obj_2, [OperatorType.SUBTRACT, OperatorType.MULTIPLY])
+    >>> feature_group.add_operators(obj_1, [ADD, SUBTRACT])
+    >>> feature_group.add_operators(obj_2, [SUBTRACT, MULTIPLY])
     >>> list(feature_group)
     [OperatorType.ADD, OperatorType.SUBTRACT, OperatorType.SUBTRACT, OperatorType.MULTIPLY]
 

--- a/elastica/modules/feature_group.py
+++ b/elastica/modules/feature_group.py
@@ -6,21 +6,50 @@ import itertools
 
 
 class FeatureGroupFIFO(Iterable):
+    """
+    A class to store the features and their corresponding operators in a FIFO manner.
+
+    Examples
+    --------
+    >>> feature_group = FeatureGroupFIFO()
+    >>> feature_group.append_id(obj_1)
+    >>> feature_group.append_id(obj_2)
+    >>> feature_group.add_operators(obj_1, [OperatorType.ADD, OperatorType.SUBTRACT])
+    >>> feature_group.add_operators(obj_2, [OperatorType.SUBTRACT, OperatorType.MULTIPLY])
+    >>> list(feature_group)
+    [OperatorType.ADD, OperatorType.SUBTRACT, OperatorType.SUBTRACT, OperatorType.MULTIPLY]
+
+    Attributes
+    ----------
+    _operator_collection : list[list[OperatorType]]
+        A list of lists of operators. Each list of operators corresponds to a feature.
+    _operator_ids : list[int]
+        A list of ids of the features.
+
+    Methods
+    -------
+    append_id(feature)
+        Appends the id of the feature to the list of ids.
+    add_operators(feature, operators)
+        Adds the operators to the list of operators corresponding to the feature.
+    """
+
     def __init__(self):
         self._operator_collection: list[list[OperatorType]] = []
         self._operator_ids: list[int] = []
 
     def __iter__(self) -> OperatorType:
-        if not self._operator_collection:
-            raise RuntimeError("Feature group is not instantiated.")
+        """Returns an operator iterator to satisfy the Iterable protocol."""
         operator_chain = itertools.chain.from_iterable(self._operator_collection)
         for operator in operator_chain:
             yield operator
 
     def append_id(self, feature):
+        """Appends the id of the feature to the list of ids."""
         self._operator_ids.append(id(feature))
         self._operator_collection.append([])
 
     def add_operators(self, feature, operators: list[OperatorType]):
+        """Adds the operators to the list of operators corresponding to the feature."""
         idx = self._operator_ids.index(id(feature))
         self._operator_collection[idx].extend(operators)

--- a/elastica/modules/feature_group.py
+++ b/elastica/modules/feature_group.py
@@ -1,4 +1,3 @@
-from typing import Callable
 from elastica.typing import OperatorType
 
 from collections.abc import Iterable
@@ -11,10 +10,10 @@ class FeatureGroupFIFO(Iterable):
         self._operator_collection: list[list[OperatorType]] = []
         self._operator_ids: list[int] = []
 
-    def __iter__(self) -> Callable[[...], None]:
+    def __iter__(self) -> OperatorType:
         if not self._operator_collection:
             raise RuntimeError("Feature group is not instantiated.")
-        operator_chain = itertools.chain(self._operator_collection)
+        operator_chain = itertools.chain.from_iterable(self._operator_collection)
         for operator in operator_chain:
             yield operator
 
@@ -23,5 +22,5 @@ class FeatureGroupFIFO(Iterable):
         self._operator_collection.append([])
 
     def add_operators(self, feature, operators: list[OperatorType]):
-        idx = self._operator_ids.index(feature)
+        idx = self._operator_ids.index(id(feature))
         self._operator_collection[idx].extend(operators)

--- a/elastica/modules/feature_group.py
+++ b/elastica/modules/feature_group.py
@@ -1,0 +1,27 @@
+from typing import Callable
+from elastica.typing import OperatorType
+
+from collection.abc import Iterable
+
+import itertools
+
+
+class FeatureGroupFIFO(Iterable):
+    def __init__(self):
+        self._operator_collection: list[list[OperatorType]] = []
+        self._operator_ids: list[int] = []
+
+    def __iter__(self) -> Callable[[...], None]:
+        if not self._operator_collection:
+            raise RuntimeError("Feature group is not instantiated.")
+        operator_chain = itertools.chain(self._operator_collection)
+        for operator in operator_chain:
+            yield operator
+
+    def append_id(self, feature):
+        self._operator_ids.append(id(feature))
+        self._operator_collection.append([])
+
+    def add_operators(self, feature, operators: list[OperatorType]):
+        idx = self._operator_idx.index(feature)
+        self._operator_collection[idx].extend(operators)

--- a/elastica/modules/feature_group.py
+++ b/elastica/modules/feature_group.py
@@ -1,7 +1,7 @@
 from typing import Callable
 from elastica.typing import OperatorType
 
-from collection.abc import Iterable
+from collections.abc import Iterable
 
 import itertools
 
@@ -23,5 +23,5 @@ class FeatureGroupFIFO(Iterable):
         self._operator_collection.append([])
 
     def add_operators(self, feature, operators: list[OperatorType]):
-        idx = self._operator_idx.index(feature)
+        idx = self._operator_ids.index(feature)
         self._operator_collection[idx].extend(operators)

--- a/elastica/modules/forcing.py
+++ b/elastica/modules/forcing.py
@@ -70,6 +70,9 @@ class Forcing:
                 ext_force_torque, [apply_forces, apply_torques]
             )
 
+        self._ext_forces_torques = []
+        del self._ext_forces_torques
+
 
 class _ExtForceTorque:
     """

--- a/elastica/modules/forcing.py
+++ b/elastica/modules/forcing.py
@@ -5,7 +5,10 @@ Forcing
 Provides the forcing interface to apply forces and torques to rod-like objects
 (external point force, muscle torques, etc).
 """
+import logging
 import functools
+
+logger = logging.getLogger(__name__)
 
 
 class Forcing:
@@ -55,9 +58,9 @@ class Forcing:
 
         # dev : the first index stores the rod index to apply the boundary condition
         # to.
-        for ext_force_torque in self._ext_forces_torques:
-            sys_id = ext_force_torque.id()
-            forcing_instance = ext_force_torque.instantiate()
+        for external_force_and_torque in self._ext_forces_torques:
+            sys_id = external_force_and_torque.id()
+            forcing_instance = external_force_and_torque.instantiate()
 
             apply_forces = functools.partial(
                 forcing_instance.apply_forces, system=self._systems[sys_id]
@@ -67,11 +70,16 @@ class Forcing:
             )
 
             self._feature_group_synchronize.add_operators(
-                ext_force_torque, [apply_forces, apply_torques]
+                external_force_and_torque, [apply_forces, apply_torques]
             )
+
+            self.warnings(external_force_and_torque)
 
         self._ext_forces_torques = []
         del self._ext_forces_torques
+
+    def warnings(self, external_force_and_torque):
+        pass
 
 
 class _ExtForceTorque:

--- a/elastica/modules/forcing.py
+++ b/elastica/modules/forcing.py
@@ -6,7 +6,6 @@ Provides the forcing interface to apply forces and torques to rod-like objects
 (external point force, muscle torques, etc).
 """
 import functools
-from elastica.interaction import AnisotropicFrictionalPlane
 
 
 class Forcing:
@@ -70,18 +69,6 @@ class Forcing:
             self._feature_group_synchronize.add_operators(
                 ext_force_torque, [apply_forces, apply_torques]
             )
-
-        # TODO: remove: we decided to let user to fully decide the order of operations
-        # Find if there are any friction plane forcing, if add them to the end of the list,
-        # since friction planes uses external forces.
-        friction_plane_index = []
-        for idx, ext_force_torque in enumerate(self._ext_forces_torques):
-            if isinstance(ext_force_torque[1], AnisotropicFrictionalPlane):
-                friction_plane_index.append(idx)
-
-        # Move to the friction forces to the end of the external force and torques list.
-        for index in friction_plane_index:
-            self._ext_forces_torques.append(self._ext_forces_torques.pop(index))
 
 
 class _ExtForceTorque:

--- a/elastica/modules/operator_group.py
+++ b/elastica/modules/operator_group.py
@@ -5,18 +5,18 @@ from collections.abc import Iterable
 import itertools
 
 
-class FeatureGroupFIFO(Iterable):
+class OperatorGroupFIFO(Iterable):
     """
     A class to store the features and their corresponding operators in a FIFO manner.
 
     Examples
     --------
-    >>> feature_group = FeatureGroupFIFO()
-    >>> feature_group.append_id(obj_1)
-    >>> feature_group.append_id(obj_2)
-    >>> feature_group.add_operators(obj_1, [ADD, SUBTRACT])
-    >>> feature_group.add_operators(obj_2, [SUBTRACT, MULTIPLY])
-    >>> list(feature_group)
+    >>> operator_group = OperatorGroupFIFO()
+    >>> operator_group.append_id(obj_1)
+    >>> operator_group.append_id(obj_2)
+    >>> operator_group.add_operators(obj_1, [ADD, SUBTRACT])
+    >>> operator_group.add_operators(obj_2, [SUBTRACT, MULTIPLY])
+    >>> list(operator_group)
     [OperatorType.ADD, OperatorType.SUBTRACT, OperatorType.SUBTRACT, OperatorType.MULTIPLY]
 
     Attributes
@@ -32,6 +32,9 @@ class FeatureGroupFIFO(Iterable):
         Appends the id of the feature to the list of ids.
     add_operators(feature, operators)
         Adds the operators to the list of operators corresponding to the feature.
+    is_last(feature)
+        Checks if the feature is the last feature in the FIFO.
+        Used to check if the specific feature is the last feature in the FIFO.
     """
 
     def __init__(self):
@@ -53,3 +56,7 @@ class FeatureGroupFIFO(Iterable):
         """Adds the operators to the list of operators corresponding to the feature."""
         idx = self._operator_ids.index(id(feature))
         self._operator_collection[idx].extend(operators)
+
+    def is_last(self, feature) -> bool:
+        """Checks if the feature is the last feature in the FIFO."""
+        return id(feature) == self._operator_ids[-1]

--- a/elastica/typing.py
+++ b/elastica/typing.py
@@ -2,8 +2,12 @@ from elastica.rod import RodBase
 from elastica.rigidbody import RigidBodyBase
 from elastica.surface import SurfaceBase
 
-from typing import Type, Union
+from typing import Type, Union, TypeAlias, Callable
 
 RodType = Type[RodBase]
 SystemType = Union[RodType, Type[RigidBodyBase]]
 AllowedContactType = Union[SystemType, Type[SurfaceBase]]
+
+OperatorType: TypeAlias = Callable[[float], None]
+OperatorCallbackType: TypeAlias = Callable[[float, int], None]
+OperatorFinalizeType: TypeAlias = Callable

--- a/tests/test_modules/test_base_system.py
+++ b/tests/test_modules/test_base_system.py
@@ -197,7 +197,18 @@ class TestBaseSystemWithFeaturesUsingCosseratRod:
         simulator_class.add_forcing_to(rod).using(legal_forces)
         simulator_class.finalize()
         # After finalize check if the created forcing object is instance of the class we have given.
-        assert isinstance(simulator_class._ext_forces_torques[-1][-1], legal_forces)
+        assert isinstance(
+            simulator_class._feature_group_synchronize._operator_collection[-1][
+                -1
+            ].func.__self__,
+            legal_forces,
+        )
+        assert isinstance(
+            simulator_class._feature_group_synchronize._operator_collection[-1][
+                -2
+            ].func.__self__,
+            legal_forces,
+        )
 
         # TODO: this is a dummy test for synchronize find a better way to test them
         simulator_class.synchronize(time=0)

--- a/tests/test_modules/test_feature_grouping.py
+++ b/tests/test_modules/test_feature_grouping.py
@@ -1,0 +1,56 @@
+from elastica.modules.feature_group import FeatureGroupFIFO
+
+
+def test_add_ids():
+    feature_group = FeatureGroupFIFO()
+    feature_group.append_id(1)
+    feature_group.append_id(2)
+    feature_group.append_id(3)
+
+    assert feature_group._operator_ids == [id(1), id(2), id(3)]
+
+
+def test_add_operators():
+    feature_group = FeatureGroupFIFO()
+    feature_group.append_id(1)
+    feature_group.add_operators(1, [1, 2, 3])
+    feature_group.append_id(2)
+    feature_group.add_operators(2, [4, 5, 6])
+    feature_group.append_id(3)
+    feature_group.add_operators(3, [7, 8, 9])
+
+    assert feature_group._operator_collection == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    assert feature_group._operator_ids == [id(1), id(2), id(3)]
+
+    feature_group.append_id(4)
+    feature_group.add_operators(4, [10, 11, 12])
+
+    assert feature_group._operator_collection == [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+    ]
+    assert feature_group._operator_ids == [id(1), id(2), id(3), id(4)]
+
+
+def test_grouping():
+    feature_group = FeatureGroupFIFO()
+    feature_group.append_id(1)
+    feature_group.add_operators(1, [1, 2, 3])
+    feature_group.append_id(2)
+    feature_group.add_operators(2, [4, 5, 6])
+    feature_group.append_id(3)
+    feature_group.add_operators(3, [7, 8, 9])
+
+    assert list(feature_group) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    feature_group.append_id(4)
+    feature_group.add_operators(4, [10, 11, 12])
+
+    assert list(feature_group) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+    feature_group.append_id(1)
+    feature_group.add_operators(1, [13, 14, 15])
+
+    assert list(feature_group) == [1, 2, 3, 13, 14, 15, 4, 5, 6, 7, 8, 9, 10, 11, 12]

--- a/tests/test_modules/test_feature_grouping.py
+++ b/tests/test_modules/test_feature_grouping.py
@@ -1,56 +1,67 @@
-from elastica.modules.feature_group import FeatureGroupFIFO
+from elastica.modules.operator_group import OperatorGroupFIFO
 
 
 def test_add_ids():
-    feature_group = FeatureGroupFIFO()
-    feature_group.append_id(1)
-    feature_group.append_id(2)
-    feature_group.append_id(3)
+    group = OperatorGroupFIFO()
+    group.append_id(1)
+    group.append_id(2)
+    group.append_id(3)
 
-    assert feature_group._operator_ids == [id(1), id(2), id(3)]
+    assert group._operator_ids == [id(1), id(2), id(3)]
 
 
 def test_add_operators():
-    feature_group = FeatureGroupFIFO()
-    feature_group.append_id(1)
-    feature_group.add_operators(1, [1, 2, 3])
-    feature_group.append_id(2)
-    feature_group.add_operators(2, [4, 5, 6])
-    feature_group.append_id(3)
-    feature_group.add_operators(3, [7, 8, 9])
+    group = OperatorGroupFIFO()
+    group.append_id(1)
+    group.add_operators(1, [1, 2, 3])
+    group.append_id(2)
+    group.add_operators(2, [4, 5, 6])
+    group.append_id(3)
+    group.add_operators(3, [7, 8, 9])
 
-    assert feature_group._operator_collection == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    assert feature_group._operator_ids == [id(1), id(2), id(3)]
+    assert group._operator_collection == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    assert group._operator_ids == [id(1), id(2), id(3)]
 
-    feature_group.append_id(4)
-    feature_group.add_operators(4, [10, 11, 12])
+    group.append_id(4)
+    group.add_operators(4, [10, 11, 12])
 
-    assert feature_group._operator_collection == [
+    assert group._operator_collection == [
         [1, 2, 3],
         [4, 5, 6],
         [7, 8, 9],
         [10, 11, 12],
     ]
-    assert feature_group._operator_ids == [id(1), id(2), id(3), id(4)]
+    assert group._operator_ids == [id(1), id(2), id(3), id(4)]
 
 
 def test_grouping():
-    feature_group = FeatureGroupFIFO()
-    feature_group.append_id(1)
-    feature_group.add_operators(1, [1, 2, 3])
-    feature_group.append_id(2)
-    feature_group.add_operators(2, [4, 5, 6])
-    feature_group.append_id(3)
-    feature_group.add_operators(3, [7, 8, 9])
+    group = OperatorGroupFIFO()
+    group.append_id(1)
+    group.add_operators(1, [1, 2, 3])
+    group.append_id(2)
+    group.add_operators(2, [4, 5, 6])
+    group.append_id(3)
+    group.add_operators(3, [7, 8, 9])
 
-    assert list(feature_group) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert list(group) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    feature_group.append_id(4)
-    feature_group.add_operators(4, [10, 11, 12])
+    group.append_id(4)
+    group.add_operators(4, [10, 11, 12])
 
-    assert list(feature_group) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    assert list(group) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
-    feature_group.append_id(1)
-    feature_group.add_operators(1, [13, 14, 15])
+    group.append_id(1)
+    group.add_operators(1, [13, 14, 15])
 
-    assert list(feature_group) == [1, 2, 3, 13, 14, 15, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    assert list(group) == [1, 2, 3, 13, 14, 15, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+
+def test_is_last():
+    group = OperatorGroupFIFO()
+    group.append_id(1)
+    group.add_operators(1, [1, 2, 3])
+    group.append_id(2)
+    group.add_operators(2, [4, 5, 6])
+
+    assert group.is_last(1) == False
+    assert group.is_last(2) == True


### PR DESCRIPTION
# Explicit operation order

- User-API would remain the same

## Description

Previous implementation has ambiguity in determining the order of operation for different boundary conditions: `forcing`, `contact`, `friction`, `connection`, etc. For example, `contact` and `friction` must be calculated after all other boundary conditions are in place, and strictly `contact` must be computed before `friction` since `friction` depends on `contact`. In various place in the code, we tried to rearange the order without explicitly letting user know: https://github.com/GazzolaLab/PyElastica/blob/87a2e74eb5cd1de0671847753efb630afaa1acf5/elastica/modules/base_system.py#L173-L182, https://github.com/GazzolaLab/PyElastica/blob/87a2e74eb5cd1de0671847753efb630afaa1acf5/elastica/modules/forcing.py#L72-L81.
This cause ambiguity on user, especially when user wants to define their own boundary condition.

## Solution

As long as we let users to write their own boundary conditions, we cannot anticipate every possible cases of operation dependencies. We are shifting to the policy that user must be aware of the boundary operation order.

This PR removes any "back-end" sorting the operation order. __Operation order is now strictly defined by the order of user inserting any boundary condition with `.using`.__ This applies to `forcing`, `contact`, and `connection` as of now.

## Some remaining TODOs:

- [x] Add warning messages on packaged `contact` and `friction` modules
- [x] Refactor synchronize operations: "first-in" boundary condition computes first
- [x] Test
  - [x] Fix existing tests
  - [x] Implement new test for testing operation order
- [x] Documentation ([f0fc544](https://github.com/GazzolaLab/PyElastica/pull/379/commits/f0fc544bb8be1458b03b41a5458ff453b04fea33))