### PR TITLE
Feature: check require-modules for each system

### DIFF
--- a/elastica/modules/base_system.py
+++ b/elastica/modules/base_system.py
@@ -56,6 +56,7 @@ class BaseSystemCollection(MutableSequence):
         self.allowed_sys_types = (RodBase, RigidBodyBase, SurfaceBase)
         # List of systems to be integrated
         self._systems = []
+        self._memory_blocks = []
         # Flag Finalize: Finalizing twice will cause an error,
         # but the error message is very misleading
         self._finalize_flag = False
@@ -72,7 +73,10 @@ class BaseSystemCollection(MutableSequence):
                 "The allowed types are\n"
                 "{1}".format(sys_to_be_added.__class__, self.allowed_sys_types)
             )
-        if not all(isinstance(self, req) for req in sys_to_be_added.REQUISITE_MODULES):
+        if not all(
+            isinstance(self, req)
+            for req in getattr(sys_to_be_added, "REQUISITE_MODULES", [])
+        ):
             raise RuntimeError(
                 f"The system {sys_to_be_added.__class__} requires the following modules:\n"
                 f"{sys_to_be_added.REQUISITE_MODULES}\n"

--- a/elastica/modules/constraints.py
+++ b/elastica/modules/constraints.py
@@ -51,6 +51,23 @@ class Constraints:
         return _constraint
 
     def _finalize_constraints(self):
+        """
+        In case memory block have ring rod, then periodic boundaries have to be synched. In order to synchronize
+        periodic boundaries, a new constrain for memory block rod added called as _ConstrainPeriodicBoundaries. This
+        constrain will synchronize the only periodic boundaries of position, director, velocity and omega variables.
+        """
+        from elastica._synchronize_periodic_boundary import _ConstrainPeriodicBoundaries
+
+        for block in self._memory_blocks:
+            # append the memory block to the simulation as a system. Memory block is the final system in the simulation.
+            if hasattr(block, "ring_rod_flag"):
+                # Apply the constrain to synchronize the periodic boundaries of the memory rod. Find the memory block
+                # sys idx among other systems added and then apply boundary conditions.
+                memory_block_idx = self._get_sys_idx_if_valid(block)
+                self.constrain(self._systems[memory_block_idx]).using(
+                    _ConstrainPeriodicBoundaries,
+                )
+
         # From stored _Constraint objects, instantiate the boundary conditions
         # inplace : https://stackoverflow.com/a/1208792
 

--- a/elastica/rigidbody/rigid_body.py
+++ b/elastica/rigidbody/rigid_body.py
@@ -15,6 +15,8 @@ class RigidBodyBase(ABC):
 
     """
 
+    REQUISITE_MODULES = []
+
     def __init__(self):
 
         self.position_collection = NotImplementedError

--- a/elastica/rod/cosserat_rod.py
+++ b/elastica/rod/cosserat_rod.py
@@ -439,6 +439,7 @@ class CosseratRod(RodBase, KnotTheory):
         CosseratRod
 
         """
+        from elastica.modules.constraints import Constraints
 
         if nu is not None:
             raise ValueError(
@@ -497,7 +498,7 @@ class CosseratRod(RodBase, KnotTheory):
             **kwargs,
         )
 
-        return cls(
+        rod = cls(
             n_elements,
             position,
             velocities,
@@ -532,6 +533,8 @@ class CosseratRod(RodBase, KnotTheory):
             internal_couple,
             ring_rod_flag,
         )
+        rod.REQUISITE_MODULE.append(Constraints)
+        return rod
 
     def compute_internal_forces_and_torques(self, time):
         """

--- a/elastica/rod/rod_base.py
+++ b/elastica/rod/rod_base.py
@@ -11,6 +11,8 @@ class RodBase:
 
     """
 
+    REQUISITE_MODULES = []
+
     def __init__(self):
         """
         RodBase does not take any arguments.

--- a/elastica/surface/surface_base.py
+++ b/elastica/surface/surface_base.py
@@ -11,6 +11,8 @@ class SurfaceBase:
 
     """
 
+    REQUISITE_MODULES = []
+
     def __init__(self):
         """
         SurfaceBase does not take any arguments.


### PR DESCRIPTION
## Description

Currently, defining `SystemCollection` was independent from what kind of `system` we append, mainly because there was no dependency between the `system` (like `CosseratRod`) and `modules` (like `Constraints` and `Damping`). Some system (mainly `ring-rod`) must require `Constraints` module, which introduce dependency between system and modules. To accomodate for such dependency in generic way, I added `REQUISITE_MODULES` class variable to each system.

In the [future update](https://github.com/skim0119/PyElastica/blob/f73628e410a4b68de4a27a5f3ccaea34741c58e6/elastica/systems/protocol.py#L16), this behavior will be added as a `System` protocol.