### PR TITLE
style: Use standard module docstring in surface/__init__.py

### DIFF
--- a/elastica/surface/__init__.py
+++ b/elastica/surface/__init__.py
@@ -1,2 +1,2 @@
-__doc__ = """Surface classes"""
+"""Surface classes"""
 from elastica.surface.plane import Plane


### PR DESCRIPTION
### 问题背景
在 `elastica/surface/__init__.py` 模块中，文档字符串是通过显式设置 `__doc__` 变量来定义的，而不是使用 Python 的标准模块 docstring（即在文件开头用三引号直接定义）。这不符合 PEP 257 的编码规范，可能导致代码风格不一致和潜在的可维护性问题。

### 修改内容
- 修改了 `elastica/surface/__init__.py` 文件，将 `__doc__ = """Surface classes"""` 替换为 `"""Surface classes"""`。
- 这样，模块的文档字符串现在是标准的 docstring 格式，提高了代码的可读性和规范性，同时遵循 Python 最佳实践。
- 没有改变任何功能或公共 API，文档字符串内容保持不变，因此对代码质量有正面提升，但不影响性能或安全性。

### 验证方式
- 运行现有的测试套件，确保所有测试通过，因为修改是纯代码风格更改，不影响功能。
- 使用 lint 工具（如 flake8 或 pylint）检查代码，确认符合 Python 编码规范，无新引入的错误。
- 手动验证模块的文档字符串是否正确设置，可以通过 `help(elastica.surface)` 或类似命令查看。

### 其他信息
- 没有 breaking changes。
- 不需要更新文档，因为文档字符串内容未变。
- 没有已知的限制。